### PR TITLE
Add Hobby Kollector storefront

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,505 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hobby Kollector | Modern Handmade Collectibles</title>
+  <meta name="description" content="Hobby Kollector is your destination for handcrafted ceramics, stickers, woodwork, metalwork, and digital assets." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;600;700&family=Urbanist:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="logo" aria-label="Hobby Kollector home">
+      <span class="logo-mark">HK</span>
+      <span class="logo-type">Hobby Kollector</span>
+    </div>
+    <nav class="primary-nav" aria-label="Primary">
+      <ul class="nav-list">
+        <li>
+          <a class="nav-link" href="#ceramics">
+            <span class="nav-icon" aria-hidden="true">
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M6 4h20l-2 12a8 8 0 01-7 6.9V28h4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M16 22.9A8 8 0 019 16L7 4h18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <span class="nav-text">Ceramics</span>
+          </a>
+        </li>
+        <li>
+          <a class="nav-link" href="#stickers">
+            <span class="nav-icon" aria-hidden="true">
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M10 5h12a3 3 0 013 3v12a7 7 0 01-7 7H9a2 2 0 01-2-2V10a5 5 0 015-5z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M18 27v-6a3 3 0 00-3-3H9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <span class="nav-text">Stickers</span>
+          </a>
+        </li>
+        <li>
+          <a class="nav-link" href="#woodwork">
+            <span class="nav-icon" aria-hidden="true">
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M6 17l5 11h10l5-11" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M11 17V4h10v13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M14 8h4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            </span>
+            <span class="nav-text">Woodwork</span>
+          </a>
+        </li>
+        <li>
+          <a class="nav-link" href="#metalwork">
+            <span class="nav-icon" aria-hidden="true">
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><circle cx="11" cy="12" r="5" fill="none" stroke="currentColor" stroke-width="2"/><circle cx="21" cy="20" r="5" fill="none" stroke="currentColor" stroke-width="2"/><path d="M15 15l2 2 2-2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <span class="nav-text">Metalwork</span>
+          </a>
+        </li>
+        <li>
+          <a class="nav-link" href="#digital">
+            <span class="nav-icon" aria-hidden="true">
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><rect x="5" y="6" width="22" height="16" rx="3" ry="3" fill="none" stroke="currentColor" stroke-width="2"/><path d="M12 26h8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            </span>
+            <span class="nav-text">Digital Assets</span>
+          </a>
+        </li>
+        <li>
+          <a class="nav-link" href="#gallery">
+            <span class="nav-icon" aria-hidden="true">
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><rect x="4" y="7" width="24" height="18" rx="3" ry="3" fill="none" stroke="currentColor" stroke-width="2"/><path d="M10 17l4-4 4 4 4-3 4 4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/></svg>
+            </span>
+            <span class="nav-text">Gallery</span>
+          </a>
+        </li>
+      </ul>
+    </nav>
+    <div class="header-actions">
+      <button class="icon-btn search" type="button" aria-label="Search">
+        <span class="icon-wrapper">
+          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="11" cy="11" r="6" fill="none" stroke="currentColor" stroke-width="2"/><line x1="16" y1="16" x2="21" y2="21" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+        </span>
+      </button>
+      <button class="icon-btn cart" type="button" aria-label="Shopping cart">
+        <span class="icon-wrapper">
+          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="9" cy="21" r="1.5" fill="currentColor"/><circle cx="18" cy="21" r="1.5" fill="currentColor"/><path d="M3 5h2l2 11h12l2-7H7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </span>
+      </button>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero" id="top">
+      <div class="hero-copy">
+        <p class="eyebrow">Limited Edition Finds · Crafted for Collectors</p>
+        <h1>Collectible artistry for every passion project.</h1>
+        <p class="hero-description">Discover an evolving catalog of rare ceramics, illustrated stickers, hand-carved woodwork, expressive metal pieces, and refined digital templates. Every release is curated for makers who love to collect stories.</p>
+        <div class="cta-group">
+          <a class="cta primary" href="#ceramics">Explore Collections</a>
+          <a class="cta secondary" href="#gallery">View Gallery</a>
+        </div>
+        <dl class="hero-stats">
+          <div>
+            <dt>Artists represented</dt>
+            <dd>28</dd>
+          </div>
+          <div>
+            <dt>Limited drops this month</dt>
+            <dd>12</dd>
+          </div>
+          <div>
+            <dt>Collector community</dt>
+            <dd>3.4k</dd>
+          </div>
+        </dl>
+      </div>
+      <div class="hero-media">
+        <div class="hero-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=900&q=80" alt="Handcrafted ceramic vase with celestial glaze" class="active" />
+            <img src="https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=900&q=80" alt="Ceramic artisan shaping clay on a wheel" />
+            <img src="https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=900&q=80" alt="Table with multiple ceramic bowls and cups" />
+          </div>
+        </div>
+        <div class="hero-note">
+          <h2>New Drop · Cosmic Clay Series</h2>
+          <p>Organic silhouettes finished with iridescent glazes inspired by nebulae. Each piece is signed and numbered.</p>
+          <a class="ghost-link" href="#ceramics">See the collection</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="category" id="ceramics">
+      <div class="section-header">
+        <div>
+          <p class="section-kicker">Ceramics</p>
+          <h2>Artisanal forms fired to perfection</h2>
+        </div>
+        <a class="section-link" href="#gallery">Browse all ceramics</a>
+      </div>
+      <div class="product-grid">
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=900&q=80" alt="Celestial blue ceramic vase" class="active" />
+            <img src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=80" alt="Glazed ceramic vases displayed together" />
+            <img src="https://images.unsplash.com/photo-1462396881884-de2c07cb95ed?auto=format&fit=crop&w=900&q=80" alt="Close-up of ceramic glaze details" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Small batch</span>
+            <h3>Celestial Bloom Vessel</h3>
+            <p>Hand-thrown porcelain with layered nebula glazes and gilded rim.</p>
+            <div class="product-meta">
+              <span class="price">$145</span>
+              <span class="availability">12 editions</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=900&q=80" alt="Stack of ceramic plates in earth tones" class="active" />
+            <img src="https://images.unsplash.com/photo-1451471016731-e963a8588be8?auto=format&fit=crop&w=900&q=80" alt="Artist painting ceramic plates" />
+            <img src="https://images.unsplash.com/photo-1522780550605-98e7b380d0bc?auto=format&fit=crop&w=900&q=80" alt="Ceramic plates with brush stroke patterns" />
+          </div>
+          <div class="product-info">
+            <span class="pill accent">Collectors' pick</span>
+            <h3>Earthbound Dinner Set</h3>
+            <p>Eight-piece stoneware set brushed with matte gradient finishes.</p>
+            <div class="product-meta">
+              <span class="price">$260</span>
+              <span class="availability">Made to order</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1551218808-94e220e084d2?auto=format&fit=crop&w=900&q=80" alt="Minimal ceramic mugs on a table" class="active" />
+            <img src="https://images.unsplash.com/photo-1481349518771-20055b2a7b24?auto=format&fit=crop&w=900&q=80" alt="Ceramic mugs arranged on a shelf" />
+            <img src="https://images.unsplash.com/photo-1510906594845-bc082582c8cc?auto=format&fit=crop&w=900&q=80" alt="Pair of ceramic cups with gradient glaze" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Studio exclusive</span>
+            <h3>Mist Horizon Cup Duo</h3>
+            <p>Soft gradient mugs with ergonomic handles and luminous sheen.</p>
+            <div class="product-meta">
+              <span class="price">$88</span>
+              <span class="availability">Set of two</span>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="category" id="stickers">
+      <div class="section-header">
+        <div>
+          <p class="section-kicker">Stickers</p>
+          <h2>Illustrated stories that stick with you</h2>
+        </div>
+        <a class="section-link" href="#gallery">Shop sticker packs</a>
+      </div>
+      <div class="product-grid">
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=900&q=80" alt="Hands sorting through illustrated stickers" class="active" />
+            <img src="https://images.unsplash.com/photo-1512436991641-6745cdb1723f?auto=format&fit=crop&w=900&q=80" alt="Sticker sheet with colorful illustrations" />
+            <img src="https://images.unsplash.com/photo-1529335764857-3f1164d1cb24?auto=format&fit=crop&w=900&q=80" alt="Sticker pack spread across a desk" />
+          </div>
+          <div class="product-info">
+            <span class="pill">New artist</span>
+            <h3>Daydreamer Decals</h3>
+            <p>Whimsical characters exploring starry skies and cozy studios.</p>
+            <div class="product-meta">
+              <span class="price">$18</span>
+              <span class="availability">Pack of 12</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1513364776144-60967b0f800f?auto=format&fit=crop&w=900&q=80" alt="Sticker-filled journal with neon accents" class="active" />
+            <img src="https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=900&q=80" alt="Close-up of holographic stickers" />
+            <img src="https://images.unsplash.com/photo-1531482615713-2afd69097998?auto=format&fit=crop&w=900&q=80" alt="Sticker sheet featuring modern shapes" />
+          </div>
+          <div class="product-info">
+            <span class="pill accent">Holographic</span>
+            <h3>Neon Pulse Sheets</h3>
+            <p>Layered neon gradients with iridescent overlays for journals and tech.</p>
+            <div class="product-meta">
+              <span class="price">$22</span>
+              <span class="availability">Limited run</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1502741338009-cac2772e18bc?auto=format&fit=crop&w=900&q=80" alt="Sticker pack featuring nature illustrations" class="active" />
+            <img src="https://images.unsplash.com/photo-1529333166433-7750a6dd5a70?auto=format&fit=crop&w=900&q=80" alt="Person peeling a sticker off a sheet" />
+            <img src="https://images.unsplash.com/photo-1521587760476-6c12a4b040da?auto=format&fit=crop&w=900&q=80" alt="Sticker sheets arranged on a table" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Eco inks</span>
+            <h3>Wander Wild Pack</h3>
+            <p>Botanical illustrations printed on recycled matte stock.</p>
+            <div class="product-meta">
+              <span class="price">$16</span>
+              <span class="availability">Set of 10</span>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="category" id="woodwork">
+      <div class="section-header">
+        <div>
+          <p class="section-kicker">Woodwork</p>
+          <h2>Heritage woodworking reimagined</h2>
+        </div>
+        <a class="section-link" href="#gallery">Discover woodwork</a>
+      </div>
+      <div class="product-grid">
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1460518451285-97b6aa326961?auto=format&fit=crop&w=900&q=80" alt="Handcrafted wooden chair" class="active" />
+            <img src="https://images.unsplash.com/photo-1445991842772-097fea258e7b?auto=format&fit=crop&w=900&q=80" alt="Woodworker carving a wooden piece" />
+            <img src="https://images.unsplash.com/photo-1479064555552-3ef4979f8908?auto=format&fit=crop&w=900&q=80" alt="Close-up of wood grain on a crafted object" />
+          </div>
+          <div class="product-info">
+            <span class="pill accent">Edition of 20</span>
+            <h3>Contour Lounge Chair</h3>
+            <p>Steam-bent walnut with woven leather seat and luminous finish.</p>
+            <div class="product-meta">
+              <span class="price">$980</span>
+              <span class="availability">Pre-order</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1455778976758-b50394e8ef21?auto=format&fit=crop&w=900&q=80" alt="Woodworker crafting a jewelry box" class="active" />
+            <img src="https://images.unsplash.com/photo-1462396881884-de2c07cb95ed?auto=format&fit=crop&w=900&q=80" alt="Wooden boxes stacked together" />
+            <img src="https://images.unsplash.com/photo-1445510861639-5651173bc5d5?auto=format&fit=crop&w=900&q=80" alt="Wood grain close-up with carved detail" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Modular</span>
+            <h3>Keepsake Vault Trio</h3>
+            <p>Magnetic joinery boxes carved from reclaimed oak and maple.</p>
+            <div class="product-meta">
+              <span class="price">$320</span>
+              <span class="availability">Set of three</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1447933601403-0c6688de566e?auto=format&fit=crop&w=900&q=80" alt="Wooden desk accessories" class="active" />
+            <img src="https://images.unsplash.com/photo-1525966222134-fcfa99b8ae77?auto=format&fit=crop&w=900&q=80" alt="Woodworker smoothing a board" />
+            <img src="https://images.unsplash.com/photo-1432139555190-58524dae6a55?auto=format&fit=crop&w=900&q=80" alt="Wooden geometric objects" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Desk essentials</span>
+            <h3>Orbit Desk Set</h3>
+            <p>Modular organizers with brass inlays for modern workspaces.</p>
+            <div class="product-meta">
+              <span class="price">$210</span>
+              <span class="availability">Ships in 1 week</span>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="category" id="metalwork">
+      <div class="section-header">
+        <div>
+          <p class="section-kicker">Metalwork</p>
+          <h2>Sculpted alloys with luminous finishes</h2>
+        </div>
+        <a class="section-link" href="#gallery">View all metalwork</a>
+      </div>
+      <div class="product-grid">
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=900&q=80" alt="Metallic sculpture with organic shape" class="active" />
+            <img src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=900&q=80" alt="Metalworker welding a sculpture" />
+            <img src="https://images.unsplash.com/photo-1522778119026-d647f0596c20?auto=format&fit=crop&w=900&q=80" alt="Polished metal art piece" />
+          </div>
+          <div class="product-info">
+            <span class="pill accent">Studio spotlight</span>
+            <h3>Lumen Flow Sculpture</h3>
+            <p>Cold-cast brass with prismatic patina and soft luminance.</p>
+            <div class="product-meta">
+              <span class="price">$640</span>
+              <span class="availability">Edition of 15</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1577086664693-894d8405334c?auto=format&fit=crop&w=900&q=80" alt="Handcrafted metal jewelry pieces" class="active" />
+            <img src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=80" alt="Craftsperson polishing metal rings" />
+            <img src="https://images.unsplash.com/photo-1503602642458-232111445657?auto=format&fit=crop&w=900&q=80" alt="Metallic art pieces displayed on a table" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Hand forged</span>
+            <h3>Orbit Halo Jewelry Set</h3>
+            <p>Sculptural cuffs and rings forged in recycled sterling silver.</p>
+            <div class="product-meta">
+              <span class="price">$290</span>
+              <span class="availability">Made to size</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1452587925148-ce544e77e70d?auto=format&fit=crop&w=900&q=80" alt="Metal lamp with geometric design" class="active" />
+            <img src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=900&q=80" alt="Metalworker shaping a lamp" />
+            <img src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=900&q=80" alt="Modern metal lamp glowing" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Ambient</span>
+            <h3>Halo Arc Lighting</h3>
+            <p>Dim-to-warm LED lamp framed by brushed titanium arcs.</p>
+            <div class="product-meta">
+              <span class="price">$420</span>
+              <span class="availability">Ships worldwide</span>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="category" id="digital">
+      <div class="section-header">
+        <div>
+          <p class="section-kicker">Digital Assets</p>
+          <h2>Templates and textures for creators</h2>
+        </div>
+        <a class="section-link" href="#gallery">Browse digital vault</a>
+      </div>
+      <div class="product-grid">
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=900&q=80" alt="Digital mockups displayed on laptop" class="active" />
+            <img src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=900&q=80" alt="Design templates on a desktop setup" />
+            <img src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=900&q=80&sat=-100" alt="Graphic designer working with templates" />
+          </div>
+          <div class="product-info">
+            <span class="pill accent">Pro kit</span>
+            <h3>Brand Launch Blueprint</h3>
+            <p>40-page Figma template suite for cohesive brand storytelling.</p>
+            <div class="product-meta">
+              <span class="price">$68</span>
+              <span class="availability">Instant download</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=900&q=80&sat=-100&blend=8c57ff&blend-mode=screen" alt="Colorful digital textures on tablet" class="active" />
+            <img src="https://images.unsplash.com/photo-1526481280695-3c4693f99254?auto=format&fit=crop&w=900&q=80" alt="Designer working on digital tablet" />
+            <img src="https://images.unsplash.com/photo-1587614382346-4ec892f9aca3?auto=format&fit=crop&w=900&q=80" alt="Abstract digital backgrounds" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Texture pack</span>
+            <h3>Chromatic Noise Overlays</h3>
+            <p>50 layered PSD textures for moody lighting and grain effects.</p>
+            <div class="product-meta">
+              <span class="price">$32</span>
+              <span class="availability">Commercial use</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=900&q=80&sat=-100&blend=67eaca&blend-mode=screen" alt="Digital moodboards displayed on monitors" class="active" />
+            <img src="https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=900&q=80" alt="Team collaborating on digital design" />
+            <img src="https://images.unsplash.com/photo-1487014679447-9f8336841d58?auto=format&fit=crop&w=900&q=80" alt="Digital design elements spread on table" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Workflow</span>
+            <h3>Creative Sprint Planner</h3>
+            <p>Notion and PDF templates to organize design sprints and retros.</p>
+            <div class="product-meta">
+              <span class="price">$24</span>
+              <span class="availability">Bundle</span>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="gallery" id="gallery">
+      <div class="section-header">
+        <div>
+          <p class="section-kicker">Gallery</p>
+          <h2>Collector moments</h2>
+        </div>
+        <a class="section-link" href="#top">Back to top</a>
+      </div>
+      <div class="gallery-grid">
+        <figure class="gallery-item hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=900&q=80" alt="Collector shelf with ceramics" class="active" />
+            <img src="https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=900&q=80&sat=-100&blend=8c57ff&blend-mode=screen" alt="Ceramics with colorful highlights" />
+            <img src="https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=900&q=80" alt="Metal and ceramic objects arranged together" />
+          </div>
+          <figcaption>Studio shelf styled by @ClayConstellations</figcaption>
+        </figure>
+        <figure class="gallery-item hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1517686469429-8bdb88b9f907?auto=format&fit=crop&w=900&q=80" alt="Artist arranging stickers on wall" class="active" />
+            <img src="https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=900&q=80" alt="Sticker wall collage" />
+            <img src="https://images.unsplash.com/photo-1529333166433-7750a6dd5a70?auto=format&fit=crop&w=900&q=80" alt="Sticker board details" />
+          </div>
+          <figcaption>Pop-up sticker lab during our spring meetup</figcaption>
+        </figure>
+        <figure class="gallery-item hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1449247709967-d4461a6a6103?auto=format&fit=crop&w=900&q=80" alt="Metal and wood art installation" class="active" />
+            <img src="https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=900&q=80&sat=-100&blend=67eaca&blend-mode=screen" alt="Metal art with teal accent" />
+            <img src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=900&q=80" alt="Close-up of ceramic vase with metal frame" />
+          </div>
+          <figcaption>Mixed media installation in the collector lounge</figcaption>
+        </figure>
+        <figure class="gallery-item hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1532960400002-577fd10ff0d9?auto=format&fit=crop&w=900&q=80" alt="Digital work displayed at community event" class="active" />
+            <img src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=900&q=80&sat=-100&blend=ffb74d&blend-mode=multiply" alt="Digital art monitors" />
+            <img src="https://images.unsplash.com/photo-1487014679447-9f8336841d58?auto=format&fit=crop&w=900&q=80" alt="Workshop participants using tablets" />
+          </div>
+          <figcaption>Digital creators showcase featuring modular templates</figcaption>
+        </figure>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="footer-grid">
+      <div>
+        <div class="logo footer-logo">
+          <span class="logo-mark">HK</span>
+          <span class="logo-type">Hobby Kollector</span>
+        </div>
+        <p>Curated goods and digital tools for collectors and makers. Join the drop list to hear about the next release first.</p>
+      </div>
+      <div>
+        <h3>Visit</h3>
+        <p>1024 Aurora Lane<br />Portland, OR 97205</p>
+      </div>
+      <div>
+        <h3>Contact</h3>
+        <ul>
+          <li><a href="mailto:hello@hobbykollector.com">hello@hobbykollector.com</a></li>
+          <li><a href="tel:+15035551234">+1 (503) 555-1234</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Follow</h3>
+        <ul class="social-list">
+          <li><a href="#">Instagram</a></li>
+          <li><a href="#">Pinterest</a></li>
+          <li><a href="#">Behance</a></li>
+        </ul>
+      </div>
+    </div>
+    <p class="footer-note">© <span id="year"></span> Hobby Kollector. All rights reserved.</p>
+  </footer>
+
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,134 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const yearField = document.getElementById('year');
+  if (yearField) {
+    yearField.textContent = new Date().getFullYear();
+  }
+
+  document.body.classList.add('scroll-animations');
+
+  const iconButtons = document.querySelectorAll('.icon-btn');
+  iconButtons.forEach((button) => {
+    const wrapper = button.querySelector('.icon-wrapper');
+    if (!wrapper) return;
+
+    let rafId = null;
+
+    const animateTo = (x, y) => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        const pullStrength = 0.32;
+        wrapper.style.transform = `translate(${x * pullStrength}px, ${y * pullStrength}px)`;
+      });
+    };
+
+    const handleMove = (event) => {
+      const rect = button.getBoundingClientRect();
+      const offsetX = event.clientX - rect.left - rect.width / 2;
+      const offsetY = event.clientY - rect.top - rect.height / 2;
+      animateTo(offsetX, offsetY);
+    };
+
+    const reset = () => {
+      cancelAnimationFrame(rafId);
+      wrapper.style.transform = 'translate(0, 0)';
+    };
+
+    button.addEventListener('mousemove', handleMove);
+    button.addEventListener('mouseenter', (event) => {
+      if (event.clientX && event.clientY) {
+        handleMove(event);
+      }
+    });
+    button.addEventListener('mouseleave', reset);
+    button.addEventListener('blur', reset);
+    button.addEventListener('touchstart', reset, { passive: true });
+  });
+
+  const observerOptions = {
+    threshold: 0.2,
+    rootMargin: '0px 0px -10% 0px'
+  };
+
+  const revealElements = () => {
+    const images = document.querySelectorAll('img');
+    images.forEach((img) => {
+      img.classList.add('reveal-on-scroll');
+    });
+
+    if ('IntersectionObserver' in window) {
+      const revealObserver = new IntersectionObserver((entries, obs) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-visible');
+            obs.unobserve(entry.target);
+          }
+        });
+      }, observerOptions);
+
+      images.forEach((img) => revealObserver.observe(img));
+    } else {
+      images.forEach((img) => img.classList.add('is-visible'));
+    }
+  };
+
+  revealElements();
+
+  const supportsHover = window.matchMedia('(hover: hover) and (pointer: fine)').matches;
+
+  const carouselContainers = document.querySelectorAll('.hover-carousel');
+  carouselContainers.forEach((container) => {
+    const stack = container.querySelector('.media-stack');
+    if (!stack) return;
+    const slides = Array.from(stack.querySelectorAll('img'));
+    if (slides.length <= 1) return;
+
+    let index = 0;
+    let intervalId = null;
+    let startTimer = null;
+
+    const showSlide = (nextIndex) => {
+      slides.forEach((slide, idx) => {
+        slide.classList.toggle('active', idx === nextIndex);
+      });
+    };
+
+    const startCarousel = () => {
+      if (intervalId) return;
+      container.classList.add('carousel-active');
+      startTimer = setTimeout(() => {
+        intervalId = setInterval(() => {
+          index = (index + 1) % slides.length;
+          showSlide(index);
+        }, 1200);
+      }, 180);
+    };
+
+    const stopCarousel = () => {
+      container.classList.remove('carousel-active');
+      clearTimeout(startTimer);
+      startTimer = null;
+      if (intervalId) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+      index = 0;
+      showSlide(index);
+    };
+
+    if (supportsHover) {
+      container.addEventListener('mouseenter', startCarousel);
+      container.addEventListener('mouseleave', stopCarousel);
+      container.addEventListener('focusin', startCarousel);
+      container.addEventListener('focusout', stopCarousel);
+    } else {
+      container.addEventListener('click', () => {
+        index = (index + 1) % slides.length;
+        showSlide(index);
+      });
+      container.addEventListener('mouseleave', () => {
+        index = 0;
+        showSlide(index);
+      });
+    }
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,675 @@
+:root {
+  --page-gradient: linear-gradient(135deg, #f1ecff 0%, #d9f5f2 45%, #ffe7f3 100%);
+  --text-color: #1f2133;
+  --muted-text: #5f6478;
+  --surface: rgba(255, 255, 255, 0.72);
+  --surface-strong: rgba(255, 255, 255, 0.92);
+  --surface-line: rgba(255, 255, 255, 0.4);
+  --accent: #6c4bff;
+  --accent-warm: #ff8a65;
+  --accent-cool: #3cc8ab;
+  --accent-soft: rgba(108, 75, 255, 0.14);
+  --shadow-soft: 0 22px 45px rgba(41, 45, 62, 0.16);
+  --shadow-strong: 0 30px 60px rgba(68, 70, 84, 0.22);
+  --radius-lg: 26px;
+  --radius-md: 18px;
+  --radius-pill: 999px;
+  --content-max: 1200px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Urbanist", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--page-gradient);
+  color: var(--text-color);
+  line-height: 1.6;
+  min-height: 100vh;
+  position: relative;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 10% 10%, rgba(108, 75, 255, 0.18), transparent 60%),
+    radial-gradient(circle at 90% 20%, rgba(60, 200, 171, 0.2), transparent 65%),
+    radial-gradient(circle at 15% 80%, rgba(255, 138, 101, 0.18), transparent 55%);
+  pointer-events: none;
+  z-index: -2;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  backdrop-filter: saturate(120%) blur(32px);
+  pointer-events: none;
+  z-index: -1;
+}
+
+main {
+  padding: 5rem min(6vw, 80px) 7rem;
+}
+
+h1,
+ h2,
+ h3,
+ h4 {
+  font-family: "Playfair Display", "Times New Roman", serif;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: #16182b;
+}
+
+p {
+  margin-top: 0.4rem;
+  margin-bottom: 1rem;
+  color: var(--muted-text);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+ a:focus-visible {
+  color: var(--accent);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.15rem min(6vw, 80px);
+  background: rgba(248, 246, 255, 0.82);
+  backdrop-filter: blur(18px) saturate(140%);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 18px 35px rgba(88, 90, 104, 0.12);
+}
+
+.logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-weight: 600;
+  font-size: 1.05rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #151728;
+}
+
+.logo-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  border-radius: 0.8rem;
+  background: linear-gradient(135deg, #6c4bff 0%, #3cc8ab 100%);
+  color: #fff;
+  font-size: 1.1rem;
+  font-weight: 700;
+  box-shadow: 0 12px 24px rgba(108, 75, 255, 0.32);
+}
+
+.primary-nav {
+  flex: 1;
+}
+
+.nav-list {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin: 0;
+  padding: 0;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.6rem 0.95rem;
+  border-radius: var(--radius-pill);
+  color: #373b50;
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  transition: color 0.3s ease, background 0.35s ease, box-shadow 0.35s ease, transform 0.35s ease;
+}
+
+.nav-link .nav-icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  transition: color 0.3s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus-visible {
+  background: linear-gradient(135deg, rgba(108, 75, 255, 0.18), rgba(60, 200, 171, 0.16));
+  color: #17192c;
+  box-shadow: 0 12px 26px rgba(76, 96, 163, 0.25);
+  transform: translateY(-2px);
+}
+
+.nav-link:hover .nav-icon svg,
+.nav-link:focus-visible .nav-icon svg {
+  color: var(--accent);
+}
+
+.nav-link:focus-visible {
+  outline: 2px solid rgba(108, 75, 255, 0.4);
+  outline-offset: 2px;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.icon-btn {
+  position: relative;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 1.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  background: var(--surface-strong);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: box-shadow 0.45s cubic-bezier(0.33, 1, 0.68, 1), transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
+  overflow: hidden;
+}
+
+.icon-btn:hover,
+.icon-btn:focus-visible {
+  box-shadow: var(--shadow-soft);
+  transform: translateY(-1px);
+}
+
+.icon-btn:focus-visible {
+  outline: 2px solid rgba(108, 75, 255, 0.4);
+  outline-offset: 2px;
+}
+
+.icon-wrapper {
+  display: inline-flex;
+  transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.icon-btn svg {
+  width: 1.4rem;
+  height: 1.4rem;
+  color: #1f2133;
+  pointer-events: none;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(2rem, 5vw, 4rem);
+  align-items: center;
+  margin-top: 3.5rem;
+  margin-bottom: 5rem;
+}
+
+.hero-copy {
+  max-width: 520px;
+}
+
+.hero-copy .eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.35em;
+  font-weight: 600;
+  color: rgba(55, 59, 80, 0.7);
+  margin-bottom: 1.5rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 5vw, 3.4rem);
+  margin-bottom: 1.2rem;
+}
+
+.hero-description {
+  font-size: 1.05rem;
+  color: #495067;
+}
+
+.cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+  margin: 2.1rem 0;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.6rem;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.cta.primary {
+  background: linear-gradient(135deg, #6c4bff 0%, #3cc8ab 100%);
+  color: #fff;
+  box-shadow: 0 16px 35px rgba(108, 75, 255, 0.35);
+}
+
+.cta.primary:hover,
+.cta.primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-strong);
+}
+
+.cta.secondary {
+  background: rgba(255, 255, 255, 0.65);
+  color: #1f2133;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.cta.secondary:hover,
+.cta.secondary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-soft);
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1.2rem;
+  margin: 2.5rem 0 0;
+}
+
+.hero-stats div {
+  background: rgba(255, 255, 255, 0.55);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.3rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.hero-stats dt {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  color: rgba(55, 59, 80, 0.7);
+  margin-bottom: 0.4rem;
+}
+
+.hero-stats dd {
+  margin: 0;
+  font-family: "Playfair Display", serif;
+  font-size: 1.6rem;
+  color: #1f2133;
+}
+
+.hero-media {
+  position: relative;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero-card .media-stack {
+  aspect-ratio: 3 / 4;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0.55));
+}
+
+.hero-note {
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  border-radius: var(--radius-lg);
+  padding: 1.6rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.hero-note h2 {
+  font-size: 1.35rem;
+  margin: 0 0 0.6rem;
+}
+
+.hero-note p {
+  margin-bottom: 1rem;
+}
+
+.ghost-link {
+  color: var(--accent);
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.ghost-link::after {
+  content: "→";
+  transition: transform 0.3s ease;
+}
+
+.ghost-link:hover::after {
+  transform: translateX(4px);
+}
+
+.category,
+.gallery {
+  margin-bottom: 6rem;
+}
+
+.section-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.section-kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(55, 59, 80, 0.7);
+  margin-bottom: 0.7rem;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.6rem);
+}
+
+.section-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  padding: 0.65rem 1.1rem;
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.section-link::after {
+  content: "↗";
+  font-size: 0.9rem;
+}
+
+.section-link:hover,
+.section-link:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(86, 100, 138, 0.18);
+}
+
+.product-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.product-card {
+  background: var(--surface);
+  border: 1px solid var(--surface-line);
+  border-radius: var(--radius-lg);
+  padding: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.3rem;
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.4s cubic-bezier(0.33, 1, 0.68, 1), box-shadow 0.4s cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+.product-card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-strong);
+}
+
+.media-stack {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.45));
+}
+
+.media-stack img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
+  opacity: 0;
+  transform: translateY(24px) scale(0.96);
+  transition: opacity 0.7s cubic-bezier(0.33, 1, 0.68, 1), transform 0.7s cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+.media-stack img.active {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  z-index: 1;
+}
+
+.product-info h3 {
+  font-size: 1.3rem;
+  margin: 0 0 0.6rem;
+}
+
+.product-info p {
+  margin: 0 0 1.1rem;
+}
+
+.product-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  color: #252942;
+}
+
+.price {
+  font-size: 1.1rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.45rem 0.85rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  background: rgba(60, 200, 171, 0.16);
+  color: #157c68;
+  font-weight: 700;
+}
+
+.pill.accent {
+  background: rgba(108, 75, 255, 0.18);
+  color: #5232d2;
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 2rem;
+}
+
+.gallery-item {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: 1.4rem;
+  border: 1px solid var(--surface-line);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  transition: transform 0.4s cubic-bezier(0.33, 1, 0.68, 1), box-shadow 0.4s cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+.gallery-item:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-strong);
+}
+
+.gallery-item figcaption {
+  font-size: 0.95rem;
+  color: #40445c;
+}
+
+.site-footer {
+  padding: 4rem min(6vw, 80px) 2rem;
+  background: rgba(248, 246, 255, 0.88);
+  border-top: 1px solid rgba(255, 255, 255, 0.6);
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.footer-grid p,
+.footer-grid a {
+  color: #454a61;
+}
+
+.footer-grid h3 {
+  margin-top: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.footer-grid ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.social-list a:hover {
+  color: var(--accent);
+}
+
+.footer-note {
+  text-align: center;
+  font-size: 0.85rem;
+  color: rgba(55, 59, 80, 0.66);
+}
+
+/* Reveal animation */
+
+body.scroll-animations .reveal-on-scroll {
+  opacity: 0;
+  transform: translateY(24px) scale(0.96);
+}
+
+body.scroll-animations .reveal-on-scroll.is-visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  transition: opacity 0.7s cubic-bezier(0.33, 1, 0.68, 1), transform 0.7s cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+.hover-carousel.carousel-active .media-stack img {
+  transition-duration: 0.45s;
+}
+
+/* Responsive adjustments */
+
+@media (max-width: 960px) {
+  .site-header {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .primary-nav {
+    order: 3;
+    width: 100%;
+  }
+
+  .nav-list {
+    justify-content: flex-start;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+  }
+
+  .header-actions {
+    order: 2;
+  }
+
+  .logo {
+    order: 1;
+  }
+}
+
+@media (max-width: 720px) {
+  main {
+    padding: 4rem min(5vw, 32px) 6rem;
+  }
+
+  .hero {
+    margin-top: 2rem;
+  }
+
+  .hero-stats {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .nav-link {
+    padding: 0.55rem 0.8rem;
+  }
+
+  .icon-btn {
+    width: 2.7rem;
+    height: 2.7rem;
+    border-radius: 1.2rem;
+  }
+
+  .hero-note {
+    padding: 1.3rem;
+  }
+
+  .product-card,
+  .gallery-item {
+    padding: 1.1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  body.scroll-animations .reveal-on-scroll,
+  .media-stack img {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- build the Hobby Kollector storefront with navigation for each craft category, featured hero, product sections, and gallery content
- design a vibrant pastel-gradient theme with interactive navigation, cards, and responsive layout refinements
- add JavaScript for pointer-following header icons, scroll-triggered image reveals, and hover-driven carousel swaps

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cc21402880832aac52dd4a28e59ac5