### PR TITLE
Align Hobby Kollector with multi-medium practice

### DIFF
--- a/assets/digital/stencil-1.svg
+++ b/assets/digital/stencil-1.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <rect width="900" height="900" rx="64" fill="#121521" />
+  <g transform="translate(120 140)">
+    <rect x="0" y="0" width="660" height="420" rx="48" fill="#1e2334" />
+    <rect x="40" y="40" width="580" height="340" rx="32" fill="#11141f" />
+    <path d="M100 300 L240 160 L380 300 Z" fill="#8c9eff" opacity="0.68" />
+    <path d="M220 320 L320 200 L480 340 Z" fill="#4fd1c5" opacity="0.55" />
+    <path d="M320 320 L500 200 L580 320 Z" fill="#ffb347" opacity="0.4" />
+    <rect x="420" y="60" width="140" height="32" rx="16" fill="#4fd1c5" opacity="0.7" />
+    <rect x="420" y="110" width="100" height="24" rx="12" fill="#8c9eff" opacity="0.7" />
+    <rect x="420" y="150" width="120" height="24" rx="12" fill="#ffb347" opacity="0.7" />
+  </g>
+  <rect x="260" y="600" width="380" height="32" rx="16" fill="#1a2132" />
+  <rect x="220" y="632" width="460" height="36" rx="18" fill="#1b2334" />
+  <rect x="360" y="668" width="180" height="90" rx="24" fill="#1a2232" />
+</svg>

--- a/assets/digital/stencil-2.svg
+++ b/assets/digital/stencil-2.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <rect width="900" height="900" rx="64" fill="#101728" />
+  <g transform="translate(120 140)">
+    <rect x="0" y="0" width="660" height="420" rx="48" fill="#1a2135" />
+    <rect x="40" y="40" width="580" height="340" rx="32" fill="#11141f" />
+    <path d="M100 300 L240 160 L380 300 Z" fill="#ff8fa3" opacity="0.68" />
+    <path d="M220 320 L320 200 L480 340 Z" fill="#6dd3ff" opacity="0.55" />
+    <path d="M320 320 L500 200 L580 320 Z" fill="#ffe97a" opacity="0.4" />
+    <rect x="420" y="60" width="140" height="32" rx="16" fill="#6dd3ff" opacity="0.7" />
+    <rect x="420" y="110" width="100" height="24" rx="12" fill="#ff8fa3" opacity="0.7" />
+    <rect x="420" y="150" width="120" height="24" rx="12" fill="#ffe97a" opacity="0.7" />
+  </g>
+  <rect x="260" y="600" width="380" height="32" rx="16" fill="#1a2132" />
+  <rect x="220" y="632" width="460" height="36" rx="18" fill="#1b2334" />
+  <rect x="360" y="668" width="180" height="90" rx="24" fill="#1a2232" />
+</svg>

--- a/assets/digital/stencil-3.svg
+++ b/assets/digital/stencil-3.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <rect width="900" height="900" rx="64" fill="#11182a" />
+  <g transform="translate(120 140)">
+    <rect x="0" y="0" width="660" height="420" rx="48" fill="#20283d" />
+    <rect x="40" y="40" width="580" height="340" rx="32" fill="#11141f" />
+    <path d="M100 300 L240 160 L380 300 Z" fill="#a88cff" opacity="0.68" />
+    <path d="M220 320 L320 200 L480 340 Z" fill="#42c6b7" opacity="0.55" />
+    <path d="M320 320 L500 200 L580 320 Z" fill="#ff9b6a" opacity="0.4" />
+    <rect x="420" y="60" width="140" height="32" rx="16" fill="#42c6b7" opacity="0.7" />
+    <rect x="420" y="110" width="100" height="24" rx="12" fill="#a88cff" opacity="0.7" />
+    <rect x="420" y="150" width="120" height="24" rx="12" fill="#ff9b6a" opacity="0.7" />
+  </g>
+  <rect x="260" y="600" width="380" height="32" rx="16" fill="#1a2132" />
+  <rect x="220" y="632" width="460" height="36" rx="18" fill="#1b2334" />
+  <rect x="360" y="668" width="180" height="90" rx="24" fill="#1a2232" />
+</svg>

--- a/assets/digital/stencil-4.svg
+++ b/assets/digital/stencil-4.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <rect width="900" height="900" rx="64" fill="#101522" />
+  <g transform="translate(120 140)">
+    <rect x="0" y="0" width="660" height="420" rx="48" fill="#1c2233" />
+    <rect x="40" y="40" width="580" height="340" rx="32" fill="#11141f" />
+    <path d="M100 300 L240 160 L380 300 Z" fill="#9bb8ff" opacity="0.68" />
+    <path d="M220 320 L320 200 L480 340 Z" fill="#5ce1e6" opacity="0.55" />
+    <path d="M320 320 L500 200 L580 320 Z" fill="#ffcc70" opacity="0.4" />
+    <rect x="420" y="60" width="140" height="32" rx="16" fill="#5ce1e6" opacity="0.7" />
+    <rect x="420" y="110" width="100" height="24" rx="12" fill="#9bb8ff" opacity="0.7" />
+    <rect x="420" y="150" width="120" height="24" rx="12" fill="#ffcc70" opacity="0.7" />
+  </g>
+  <rect x="260" y="600" width="380" height="32" rx="16" fill="#1a2132" />
+  <rect x="220" y="632" width="460" height="36" rx="18" fill="#1b2334" />
+  <rect x="360" y="668" width="180" height="90" rx="24" fill="#1a2232" />
+</svg>

--- a/assets/digital/stencil-5.svg
+++ b/assets/digital/stencil-5.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <rect width="900" height="900" rx="64" fill="#0f1421" />
+  <g transform="translate(120 140)">
+    <rect x="0" y="0" width="660" height="420" rx="48" fill="#1e2538" />
+    <rect x="40" y="40" width="580" height="340" rx="32" fill="#11141f" />
+    <path d="M100 300 L240 160 L380 300 Z" fill="#ff94b3" opacity="0.68" />
+    <path d="M220 320 L320 200 L480 340 Z" fill="#6ec7ff" opacity="0.55" />
+    <path d="M320 320 L500 200 L580 320 Z" fill="#ffd86b" opacity="0.4" />
+    <rect x="420" y="60" width="140" height="32" rx="16" fill="#6ec7ff" opacity="0.7" />
+    <rect x="420" y="110" width="100" height="24" rx="12" fill="#ff94b3" opacity="0.7" />
+    <rect x="420" y="150" width="120" height="24" rx="12" fill="#ffd86b" opacity="0.7" />
+  </g>
+  <rect x="260" y="600" width="380" height="32" rx="16" fill="#1a2132" />
+  <rect x="220" y="632" width="460" height="36" rx="18" fill="#1b2334" />
+  <rect x="360" y="668" width="180" height="90" rx="24" fill="#1a2232" />
+</svg>

--- a/assets/digital/stencil-6.svg
+++ b/assets/digital/stencil-6.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <rect width="900" height="900" rx="64" fill="#111728" />
+  <g transform="translate(120 140)">
+    <rect x="0" y="0" width="660" height="420" rx="48" fill="#242c40" />
+    <rect x="40" y="40" width="580" height="340" rx="32" fill="#11141f" />
+    <path d="M100 300 L240 160 L380 300 Z" fill="#b69cff" opacity="0.68" />
+    <path d="M220 320 L320 200 L480 340 Z" fill="#46d9a8" opacity="0.55" />
+    <path d="M320 320 L500 200 L580 320 Z" fill="#ff9c6c" opacity="0.4" />
+    <rect x="420" y="60" width="140" height="32" rx="16" fill="#46d9a8" opacity="0.7" />
+    <rect x="420" y="110" width="100" height="24" rx="12" fill="#b69cff" opacity="0.7" />
+    <rect x="420" y="150" width="120" height="24" rx="12" fill="#ff9c6c" opacity="0.7" />
+  </g>
+  <rect x="260" y="600" width="380" height="32" rx="16" fill="#1a2132" />
+  <rect x="220" y="632" width="460" height="36" rx="18" fill="#1b2334" />
+  <rect x="360" y="668" width="180" height="90" rx="24" fill="#1a2232" />
+</svg>

--- a/assets/digital/stencil-7.svg
+++ b/assets/digital/stencil-7.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <rect width="900" height="900" rx="64" fill="#101622" />
+  <g transform="translate(120 140)">
+    <rect x="0" y="0" width="660" height="420" rx="48" fill="#1f283b" />
+    <rect x="40" y="40" width="580" height="340" rx="32" fill="#11141f" />
+    <path d="M100 300 L240 160 L380 300 Z" fill="#86a4ff" opacity="0.68" />
+    <path d="M220 320 L320 200 L480 340 Z" fill="#54d2c5" opacity="0.55" />
+    <path d="M320 320 L500 200 L580 320 Z" fill="#ffbf69" opacity="0.4" />
+    <rect x="420" y="60" width="140" height="32" rx="16" fill="#54d2c5" opacity="0.7" />
+    <rect x="420" y="110" width="100" height="24" rx="12" fill="#86a4ff" opacity="0.7" />
+    <rect x="420" y="150" width="120" height="24" rx="12" fill="#ffbf69" opacity="0.7" />
+  </g>
+  <rect x="260" y="600" width="380" height="32" rx="16" fill="#1a2132" />
+  <rect x="220" y="632" width="460" height="36" rx="18" fill="#1b2334" />
+  <rect x="360" y="668" width="180" height="90" rx="24" fill="#1a2232" />
+</svg>

--- a/assets/digital/stencil-8.svg
+++ b/assets/digital/stencil-8.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <rect width="900" height="900" rx="64" fill="#0f1726" />
+  <g transform="translate(120 140)">
+    <rect x="0" y="0" width="660" height="420" rx="48" fill="#202a3f" />
+    <rect x="40" y="40" width="580" height="340" rx="32" fill="#11141f" />
+    <path d="M100 300 L240 160 L380 300 Z" fill="#ff8ba5" opacity="0.68" />
+    <path d="M220 320 L320 200 L480 340 Z" fill="#65d4ff" opacity="0.55" />
+    <path d="M320 320 L500 200 L580 320 Z" fill="#ffe37a" opacity="0.4" />
+    <rect x="420" y="60" width="140" height="32" rx="16" fill="#65d4ff" opacity="0.7" />
+    <rect x="420" y="110" width="100" height="24" rx="12" fill="#ff8ba5" opacity="0.7" />
+    <rect x="420" y="150" width="120" height="24" rx="12" fill="#ffe37a" opacity="0.7" />
+  </g>
+  <rect x="260" y="600" width="380" height="32" rx="16" fill="#1a2132" />
+  <rect x="220" y="632" width="460" height="36" rx="18" fill="#1b2334" />
+  <rect x="360" y="668" width="180" height="90" rx="24" fill="#1a2232" />
+</svg>

--- a/assets/digital/stencil-9.svg
+++ b/assets/digital/stencil-9.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <rect width="900" height="900" rx="64" fill="#101527" />
+  <g transform="translate(120 140)">
+    <rect x="0" y="0" width="660" height="420" rx="48" fill="#222b3f" />
+    <rect x="40" y="40" width="580" height="340" rx="32" fill="#11141f" />
+    <path d="M100 300 L240 160 L380 300 Z" fill="#b393ff" opacity="0.68" />
+    <path d="M220 320 L320 200 L480 340 Z" fill="#4fd2b8" opacity="0.55" />
+    <path d="M320 320 L500 200 L580 320 Z" fill="#ff996d" opacity="0.4" />
+    <rect x="420" y="60" width="140" height="32" rx="16" fill="#4fd2b8" opacity="0.7" />
+    <rect x="420" y="110" width="100" height="24" rx="12" fill="#b393ff" opacity="0.7" />
+    <rect x="420" y="150" width="120" height="24" rx="12" fill="#ff996d" opacity="0.7" />
+  </g>
+  <rect x="260" y="600" width="380" height="32" rx="16" fill="#1a2132" />
+  <rect x="220" y="632" width="460" height="36" rx="18" fill="#1b2334" />
+  <rect x="360" y="668" width="180" height="90" rx="24" fill="#1a2232" />
+</svg>

--- a/assets/painting/brushscape-1.svg
+++ b/assets/painting/brushscape-1.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f6f0ff" />
+      <stop offset="100%" stop-color="#d2e0ff" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#bg)" />
+  <g transform="translate(150 140)">
+    <rect x="0" y="0" width="600" height="620" rx="48" fill="#0e0e0e12" />
+    <rect x="36" y="36" width="528" height="548" rx="36" fill="#fdfbfd" stroke="#ffffffb8" stroke-width="6" />
+    <path d="M120 340 C 220 280, 320 420, 420 360" fill="none" stroke="#5b4bff" stroke-width="36" stroke-linecap="round" stroke-linejoin="round" opacity="0.85" />
+    <path d="M160 220 C 240 160, 320 200, 400 120" fill="none" stroke="#ff7f9a" stroke-width="24" stroke-linecap="round" stroke-linejoin="round" opacity="0.75" />
+    <path d="M140 440 C 260 500, 360 480, 420 540" fill="none" stroke="#ffa12b" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+    <circle cx="460" cy="220" r="42" fill="#ff7f9a" opacity="0.85" />
+    <circle cx="220" cy="170" r="28" fill="#ffa12b" opacity="0.7" />
+    <circle cx="360" cy="460" r="36" fill="#5b4bff" opacity="0.6" />
+  </g>
+  <g transform="translate(620 720)">
+    <rect x="-40" y="-80" width="24" height="160" rx="10" fill="#d9b38c" />
+    <rect x="-38" y="-60" width="20" height="120" rx="8" fill="#c28d5a" />
+    <ellipse cx="-28" cy="-62" rx="22" ry="14" fill="#caa57a" />
+  </g>
+</svg>

--- a/assets/painting/brushscape-2.svg
+++ b/assets/painting/brushscape-2.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fdf1f4" />
+      <stop offset="100%" stop-color="#ffe5c7" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#bg)" />
+  <g transform="translate(150 140)">
+    <rect x="0" y="0" width="600" height="620" rx="48" fill="#0e0e0e12" />
+    <rect x="36" y="36" width="528" height="548" rx="36" fill="#fffaf6" stroke="#ffffffb8" stroke-width="6" />
+    <path d="M120 340 C 220 280, 320 420, 420 360" fill="none" stroke="#fa6e6e" stroke-width="36" stroke-linecap="round" stroke-linejoin="round" opacity="0.85" />
+    <path d="M160 220 C 240 160, 320 200, 400 120" fill="none" stroke="#8361ff" stroke-width="24" stroke-linecap="round" stroke-linejoin="round" opacity="0.75" />
+    <path d="M140 440 C 260 500, 360 480, 420 540" fill="none" stroke="#30c3a6" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+    <circle cx="460" cy="220" r="42" fill="#8361ff" opacity="0.85" />
+    <circle cx="220" cy="170" r="28" fill="#30c3a6" opacity="0.7" />
+    <circle cx="360" cy="460" r="36" fill="#fa6e6e" opacity="0.6" />
+  </g>
+  <g transform="translate(620 720)">
+    <rect x="-40" y="-80" width="24" height="160" rx="10" fill="#d9b38c" />
+    <rect x="-38" y="-60" width="20" height="120" rx="8" fill="#c28d5a" />
+    <ellipse cx="-28" cy="-62" rx="22" ry="14" fill="#caa57a" />
+  </g>
+</svg>

--- a/assets/painting/brushscape-3.svg
+++ b/assets/painting/brushscape-3.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#eef9ff" />
+      <stop offset="100%" stop-color="#d1f1ff" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#bg)" />
+  <g transform="translate(150 140)">
+    <rect x="0" y="0" width="600" height="620" rx="48" fill="#0e0e0e12" />
+    <rect x="36" y="36" width="528" height="548" rx="36" fill="#ffffff" stroke="#ffffffb8" stroke-width="6" />
+    <path d="M120 340 C 220 280, 320 420, 420 360" fill="none" stroke="#2e8bff" stroke-width="36" stroke-linecap="round" stroke-linejoin="round" opacity="0.85" />
+    <path d="M160 220 C 240 160, 320 200, 400 120" fill="none" stroke="#ffb347" stroke-width="24" stroke-linecap="round" stroke-linejoin="round" opacity="0.75" />
+    <path d="M140 440 C 260 500, 360 480, 420 540" fill="none" stroke="#6a4bff" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+    <circle cx="460" cy="220" r="42" fill="#ffb347" opacity="0.85" />
+    <circle cx="220" cy="170" r="28" fill="#6a4bff" opacity="0.7" />
+    <circle cx="360" cy="460" r="36" fill="#2e8bff" opacity="0.6" />
+  </g>
+  <g transform="translate(620 720)">
+    <rect x="-40" y="-80" width="24" height="160" rx="10" fill="#d9b38c" />
+    <rect x="-38" y="-60" width="20" height="120" rx="8" fill="#c28d5a" />
+    <ellipse cx="-28" cy="-62" rx="22" ry="14" fill="#caa57a" />
+  </g>
+</svg>

--- a/assets/painting/brushscape-4.svg
+++ b/assets/painting/brushscape-4.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f4edff" />
+      <stop offset="100%" stop-color="#e4f7ff" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#bg)" />
+  <g transform="translate(150 140)">
+    <rect x="0" y="0" width="600" height="620" rx="48" fill="#0e0e0e12" />
+    <rect x="36" y="36" width="528" height="548" rx="36" fill="#ffffff" stroke="#ffffffb8" stroke-width="6" />
+    <path d="M120 340 C 220 280, 320 420, 420 360" fill="none" stroke="#8c4bff" stroke-width="36" stroke-linecap="round" stroke-linejoin="round" opacity="0.85" />
+    <path d="M160 220 C 240 160, 320 200, 400 120" fill="none" stroke="#ff9fb6" stroke-width="24" stroke-linecap="round" stroke-linejoin="round" opacity="0.75" />
+    <path d="M140 440 C 260 500, 360 480, 420 540" fill="none" stroke="#3bd1c4" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+    <circle cx="460" cy="220" r="42" fill="#ff9fb6" opacity="0.85" />
+    <circle cx="220" cy="170" r="28" fill="#3bd1c4" opacity="0.7" />
+    <circle cx="360" cy="460" r="36" fill="#8c4bff" opacity="0.6" />
+  </g>
+  <g transform="translate(620 720)">
+    <rect x="-40" y="-80" width="24" height="160" rx="10" fill="#d9b38c" />
+    <rect x="-38" y="-60" width="20" height="120" rx="8" fill="#c28d5a" />
+    <ellipse cx="-28" cy="-62" rx="22" ry="14" fill="#caa57a" />
+  </g>
+</svg>

--- a/assets/painting/brushscape-5.svg
+++ b/assets/painting/brushscape-5.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fff4f4" />
+      <stop offset="100%" stop-color="#ffdcdc" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#bg)" />
+  <g transform="translate(150 140)">
+    <rect x="0" y="0" width="600" height="620" rx="48" fill="#0e0e0e12" />
+    <rect x="36" y="36" width="528" height="548" rx="36" fill="#fffdf7" stroke="#ffffffb8" stroke-width="6" />
+    <path d="M120 340 C 220 280, 320 420, 420 360" fill="none" stroke="#ff6d6d" stroke-width="36" stroke-linecap="round" stroke-linejoin="round" opacity="0.85" />
+    <path d="M160 220 C 240 160, 320 200, 400 120" fill="none" stroke="#ffd25f" stroke-width="24" stroke-linecap="round" stroke-linejoin="round" opacity="0.75" />
+    <path d="M140 440 C 260 500, 360 480, 420 540" fill="none" stroke="#5f7fff" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+    <circle cx="460" cy="220" r="42" fill="#ffd25f" opacity="0.85" />
+    <circle cx="220" cy="170" r="28" fill="#5f7fff" opacity="0.7" />
+    <circle cx="360" cy="460" r="36" fill="#ff6d6d" opacity="0.6" />
+  </g>
+  <g transform="translate(620 720)">
+    <rect x="-40" y="-80" width="24" height="160" rx="10" fill="#d9b38c" />
+    <rect x="-38" y="-60" width="20" height="120" rx="8" fill="#c28d5a" />
+    <ellipse cx="-28" cy="-62" rx="22" ry="14" fill="#caa57a" />
+  </g>
+</svg>

--- a/assets/painting/brushscape-6.svg
+++ b/assets/painting/brushscape-6.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f9f9ff" />
+      <stop offset="100%" stop-color="#d7e2ff" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#bg)" />
+  <g transform="translate(150 140)">
+    <rect x="0" y="0" width="600" height="620" rx="48" fill="#0e0e0e12" />
+    <rect x="36" y="36" width="528" height="548" rx="36" fill="#ffffff" stroke="#ffffffb8" stroke-width="6" />
+    <path d="M120 340 C 220 280, 320 420, 420 360" fill="none" stroke="#5b66ff" stroke-width="36" stroke-linecap="round" stroke-linejoin="round" opacity="0.85" />
+    <path d="M160 220 C 240 160, 320 200, 400 120" fill="none" stroke="#ff7c6b" stroke-width="24" stroke-linecap="round" stroke-linejoin="round" opacity="0.75" />
+    <path d="M140 440 C 260 500, 360 480, 420 540" fill="none" stroke="#4cd4c2" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+    <circle cx="460" cy="220" r="42" fill="#ff7c6b" opacity="0.85" />
+    <circle cx="220" cy="170" r="28" fill="#4cd4c2" opacity="0.7" />
+    <circle cx="360" cy="460" r="36" fill="#5b66ff" opacity="0.6" />
+  </g>
+  <g transform="translate(620 720)">
+    <rect x="-40" y="-80" width="24" height="160" rx="10" fill="#d9b38c" />
+    <rect x="-38" y="-60" width="20" height="120" rx="8" fill="#c28d5a" />
+    <ellipse cx="-28" cy="-62" rx="22" ry="14" fill="#caa57a" />
+  </g>
+</svg>

--- a/assets/painting/brushscape-7.svg
+++ b/assets/painting/brushscape-7.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f5fbff" />
+      <stop offset="100%" stop-color="#e0f4ff" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#bg)" />
+  <g transform="translate(150 140)">
+    <rect x="0" y="0" width="600" height="620" rx="48" fill="#0e0e0e12" />
+    <rect x="36" y="36" width="528" height="548" rx="36" fill="#ffffff" stroke="#ffffffb8" stroke-width="6" />
+    <path d="M120 340 C 220 280, 320 420, 420 360" fill="none" stroke="#2f8c8c" stroke-width="36" stroke-linecap="round" stroke-linejoin="round" opacity="0.85" />
+    <path d="M160 220 C 240 160, 320 200, 400 120" fill="none" stroke="#ffa89c" stroke-width="24" stroke-linecap="round" stroke-linejoin="round" opacity="0.75" />
+    <path d="M140 440 C 260 500, 360 480, 420 540" fill="none" stroke="#8a63ff" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+    <circle cx="460" cy="220" r="42" fill="#ffa89c" opacity="0.85" />
+    <circle cx="220" cy="170" r="28" fill="#8a63ff" opacity="0.7" />
+    <circle cx="360" cy="460" r="36" fill="#2f8c8c" opacity="0.6" />
+  </g>
+  <g transform="translate(620 720)">
+    <rect x="-40" y="-80" width="24" height="160" rx="10" fill="#d9b38c" />
+    <rect x="-38" y="-60" width="20" height="120" rx="8" fill="#c28d5a" />
+    <ellipse cx="-28" cy="-62" rx="22" ry="14" fill="#caa57a" />
+  </g>
+</svg>

--- a/assets/painting/brushscape-8.svg
+++ b/assets/painting/brushscape-8.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fff6f0" />
+      <stop offset="100%" stop-color="#ffe0d1" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#bg)" />
+  <g transform="translate(150 140)">
+    <rect x="0" y="0" width="600" height="620" rx="48" fill="#0e0e0e12" />
+    <rect x="36" y="36" width="528" height="548" rx="36" fill="#fffbf6" stroke="#ffffffb8" stroke-width="6" />
+    <path d="M120 340 C 220 280, 320 420, 420 360" fill="none" stroke="#ff8052" stroke-width="36" stroke-linecap="round" stroke-linejoin="round" opacity="0.85" />
+    <path d="M160 220 C 240 160, 320 200, 400 120" fill="none" stroke="#6d7cff" stroke-width="24" stroke-linecap="round" stroke-linejoin="round" opacity="0.75" />
+    <path d="M140 440 C 260 500, 360 480, 420 540" fill="none" stroke="#35c2b1" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+    <circle cx="460" cy="220" r="42" fill="#6d7cff" opacity="0.85" />
+    <circle cx="220" cy="170" r="28" fill="#35c2b1" opacity="0.7" />
+    <circle cx="360" cy="460" r="36" fill="#ff8052" opacity="0.6" />
+  </g>
+  <g transform="translate(620 720)">
+    <rect x="-40" y="-80" width="24" height="160" rx="10" fill="#d9b38c" />
+    <rect x="-38" y="-60" width="20" height="120" rx="8" fill="#c28d5a" />
+    <ellipse cx="-28" cy="-62" rx="22" ry="14" fill="#caa57a" />
+  </g>
+</svg>

--- a/assets/painting/brushscape-9.svg
+++ b/assets/painting/brushscape-9.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f2f7ff" />
+      <stop offset="100%" stop-color="#d7e3ff" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#bg)" />
+  <g transform="translate(150 140)">
+    <rect x="0" y="0" width="600" height="620" rx="48" fill="#0e0e0e12" />
+    <rect x="36" y="36" width="528" height="548" rx="36" fill="#ffffff" stroke="#ffffffb8" stroke-width="6" />
+    <path d="M120 340 C 220 280, 320 420, 420 360" fill="none" stroke="#6279ff" stroke-width="36" stroke-linecap="round" stroke-linejoin="round" opacity="0.85" />
+    <path d="M160 220 C 240 160, 320 200, 400 120" fill="none" stroke="#ffd369" stroke-width="24" stroke-linecap="round" stroke-linejoin="round" opacity="0.75" />
+    <path d="M140 440 C 260 500, 360 480, 420 540" fill="none" stroke="#ff819f" stroke-width="28" stroke-linecap="round" stroke-linejoin="round" opacity="0.8" />
+    <circle cx="460" cy="220" r="42" fill="#ffd369" opacity="0.85" />
+    <circle cx="220" cy="170" r="28" fill="#ff819f" opacity="0.7" />
+    <circle cx="360" cy="460" r="36" fill="#6279ff" opacity="0.6" />
+  </g>
+  <g transform="translate(620 720)">
+    <rect x="-40" y="-80" width="24" height="160" rx="10" fill="#d9b38c" />
+    <rect x="-38" y="-60" width="20" height="120" rx="8" fill="#c28d5a" />
+    <ellipse cx="-28" cy="-62" rx="22" ry="14" fill="#caa57a" />
+  </g>
+</svg>

--- a/assets/woodwork/carving-1.svg
+++ b/assets/woodwork/carving-1.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="wood-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f3e3d3" />
+      <stop offset="100%" stop-color="#e5c9a8" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#wood-bg)" />
+  <g transform="translate(160 140)">
+    <rect x="80" y="80" width="200" height="480" rx="60" fill="#c48f55" />
+    <rect x="360" y="120" width="220" height="440" rx="72" fill="#c48f55" opacity="0.92" />
+    <rect x="230" y="340" width="140" height="220" rx="48" fill="#a76d3b" opacity="0.7" />
+    <path d="M120 240 C 200 180, 160 120, 200 80" fill="none" stroke="#f9d8a7" stroke-width="22" stroke-linecap="round" opacity="0.7" />
+    <path d="M410 220 C 470 170, 490 240, 520 200" fill="none" stroke="#f9d8a7" stroke-width="20" stroke-linecap="round" opacity="0.65" />
+    <path d="M160 420 Q 220 360 260 420" fill="none" stroke="#a76d3b" stroke-width="24" stroke-linecap="round" opacity="0.75" />
+    <circle cx="180" cy="220" r="24" fill="#fff6e8" opacity="0.75" />
+    <circle cx="220" cy="220" r="24" fill="#fff6e8" opacity="0.65" />
+    <circle cx="430" cy="250" r="26" fill="#fff6e8" opacity="0.7" />
+    <circle cx="470" cy="250" r="26" fill="#fff6e8" opacity="0.6" />
+    <path d="M390 420 Q 450 360 510 420" fill="none" stroke="#a76d3b" stroke-width="24" stroke-linecap="round" opacity="0.7" />
+  </g>
+</svg>

--- a/assets/woodwork/carving-2.svg
+++ b/assets/woodwork/carving-2.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="wood-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f4e9dc" />
+      <stop offset="100%" stop-color="#e8d2b5" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#wood-bg)" />
+  <g transform="translate(160 140)">
+    <rect x="80" y="80" width="200" height="480" rx="60" fill="#b6783b" />
+    <rect x="360" y="120" width="220" height="440" rx="72" fill="#b6783b" opacity="0.92" />
+    <rect x="230" y="340" width="140" height="220" rx="48" fill="#92582c" opacity="0.7" />
+    <path d="M120 240 C 200 180, 160 120, 200 80" fill="none" stroke="#f6cf94" stroke-width="22" stroke-linecap="round" opacity="0.7" />
+    <path d="M410 220 C 470 170, 490 240, 520 200" fill="none" stroke="#f6cf94" stroke-width="20" stroke-linecap="round" opacity="0.65" />
+    <path d="M160 420 Q 220 360 260 420" fill="none" stroke="#92582c" stroke-width="24" stroke-linecap="round" opacity="0.75" />
+    <circle cx="180" cy="220" r="24" fill="#fff6e8" opacity="0.75" />
+    <circle cx="220" cy="220" r="24" fill="#fff6e8" opacity="0.65" />
+    <circle cx="430" cy="250" r="26" fill="#fff6e8" opacity="0.7" />
+    <circle cx="470" cy="250" r="26" fill="#fff6e8" opacity="0.6" />
+    <path d="M390 420 Q 450 360 510 420" fill="none" stroke="#92582c" stroke-width="24" stroke-linecap="round" opacity="0.7" />
+  </g>
+</svg>

--- a/assets/woodwork/carving-3.svg
+++ b/assets/woodwork/carving-3.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="wood-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f5eddc" />
+      <stop offset="100%" stop-color="#dfc6a4" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#wood-bg)" />
+  <g transform="translate(160 140)">
+    <rect x="80" y="80" width="200" height="480" rx="60" fill="#c08c54" />
+    <rect x="360" y="120" width="220" height="440" rx="72" fill="#c08c54" opacity="0.92" />
+    <rect x="230" y="340" width="140" height="220" rx="48" fill="#9a6b3a" opacity="0.7" />
+    <path d="M120 240 C 200 180, 160 120, 200 80" fill="none" stroke="#fce1b9" stroke-width="22" stroke-linecap="round" opacity="0.7" />
+    <path d="M410 220 C 470 170, 490 240, 520 200" fill="none" stroke="#fce1b9" stroke-width="20" stroke-linecap="round" opacity="0.65" />
+    <path d="M160 420 Q 220 360 260 420" fill="none" stroke="#9a6b3a" stroke-width="24" stroke-linecap="round" opacity="0.75" />
+    <circle cx="180" cy="220" r="24" fill="#fff6e8" opacity="0.75" />
+    <circle cx="220" cy="220" r="24" fill="#fff6e8" opacity="0.65" />
+    <circle cx="430" cy="250" r="26" fill="#fff6e8" opacity="0.7" />
+    <circle cx="470" cy="250" r="26" fill="#fff6e8" opacity="0.6" />
+    <path d="M390 420 Q 450 360 510 420" fill="none" stroke="#9a6b3a" stroke-width="24" stroke-linecap="round" opacity="0.7" />
+  </g>
+</svg>

--- a/assets/woodwork/carving-4.svg
+++ b/assets/woodwork/carving-4.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="wood-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f7eeda" />
+      <stop offset="100%" stop-color="#e3cfab" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#wood-bg)" />
+  <g transform="translate(160 140)">
+    <rect x="80" y="80" width="200" height="480" rx="60" fill="#caa070" />
+    <rect x="360" y="120" width="220" height="440" rx="72" fill="#caa070" opacity="0.92" />
+    <rect x="230" y="340" width="140" height="220" rx="48" fill="#a17845" opacity="0.7" />
+    <path d="M120 240 C 200 180, 160 120, 200 80" fill="none" stroke="#ffe3b9" stroke-width="22" stroke-linecap="round" opacity="0.7" />
+    <path d="M410 220 C 470 170, 490 240, 520 200" fill="none" stroke="#ffe3b9" stroke-width="20" stroke-linecap="round" opacity="0.65" />
+    <path d="M160 420 Q 220 360 260 420" fill="none" stroke="#a17845" stroke-width="24" stroke-linecap="round" opacity="0.75" />
+    <circle cx="180" cy="220" r="24" fill="#fff6e8" opacity="0.75" />
+    <circle cx="220" cy="220" r="24" fill="#fff6e8" opacity="0.65" />
+    <circle cx="430" cy="250" r="26" fill="#fff6e8" opacity="0.7" />
+    <circle cx="470" cy="250" r="26" fill="#fff6e8" opacity="0.6" />
+    <path d="M390 420 Q 450 360 510 420" fill="none" stroke="#a17845" stroke-width="24" stroke-linecap="round" opacity="0.7" />
+  </g>
+</svg>

--- a/assets/woodwork/carving-5.svg
+++ b/assets/woodwork/carving-5.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="wood-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f2e6d4" />
+      <stop offset="100%" stop-color="#debe8b" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#wood-bg)" />
+  <g transform="translate(160 140)">
+    <rect x="80" y="80" width="200" height="480" rx="60" fill="#b97a3b" />
+    <rect x="360" y="120" width="220" height="440" rx="72" fill="#b97a3b" opacity="0.92" />
+    <rect x="230" y="340" width="140" height="220" rx="48" fill="#8d5727" opacity="0.7" />
+    <path d="M120 240 C 200 180, 160 120, 200 80" fill="none" stroke="#f6cd93" stroke-width="22" stroke-linecap="round" opacity="0.7" />
+    <path d="M410 220 C 470 170, 490 240, 520 200" fill="none" stroke="#f6cd93" stroke-width="20" stroke-linecap="round" opacity="0.65" />
+    <path d="M160 420 Q 220 360 260 420" fill="none" stroke="#8d5727" stroke-width="24" stroke-linecap="round" opacity="0.75" />
+    <circle cx="180" cy="220" r="24" fill="#fff6e8" opacity="0.75" />
+    <circle cx="220" cy="220" r="24" fill="#fff6e8" opacity="0.65" />
+    <circle cx="430" cy="250" r="26" fill="#fff6e8" opacity="0.7" />
+    <circle cx="470" cy="250" r="26" fill="#fff6e8" opacity="0.6" />
+    <path d="M390 420 Q 450 360 510 420" fill="none" stroke="#8d5727" stroke-width="24" stroke-linecap="round" opacity="0.7" />
+  </g>
+</svg>

--- a/assets/woodwork/carving-6.svg
+++ b/assets/woodwork/carving-6.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="wood-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f6eee1" />
+      <stop offset="100%" stop-color="#e3d1b3" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#wood-bg)" />
+  <g transform="translate(160 140)">
+    <rect x="80" y="80" width="200" height="480" rx="60" fill="#c78c4f" />
+    <rect x="360" y="120" width="220" height="440" rx="72" fill="#c78c4f" opacity="0.92" />
+    <rect x="230" y="340" width="140" height="220" rx="48" fill="#a06933" opacity="0.7" />
+    <path d="M120 240 C 200 180, 160 120, 200 80" fill="none" stroke="#f9dfa9" stroke-width="22" stroke-linecap="round" opacity="0.7" />
+    <path d="M410 220 C 470 170, 490 240, 520 200" fill="none" stroke="#f9dfa9" stroke-width="20" stroke-linecap="round" opacity="0.65" />
+    <path d="M160 420 Q 220 360 260 420" fill="none" stroke="#a06933" stroke-width="24" stroke-linecap="round" opacity="0.75" />
+    <circle cx="180" cy="220" r="24" fill="#fff6e8" opacity="0.75" />
+    <circle cx="220" cy="220" r="24" fill="#fff6e8" opacity="0.65" />
+    <circle cx="430" cy="250" r="26" fill="#fff6e8" opacity="0.7" />
+    <circle cx="470" cy="250" r="26" fill="#fff6e8" opacity="0.6" />
+    <path d="M390 420 Q 450 360 510 420" fill="none" stroke="#a06933" stroke-width="24" stroke-linecap="round" opacity="0.7" />
+  </g>
+</svg>

--- a/assets/woodwork/carving-7.svg
+++ b/assets/woodwork/carving-7.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="wood-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f3e5d0" />
+      <stop offset="100%" stop-color="#dcb88a" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#wood-bg)" />
+  <g transform="translate(160 140)">
+    <rect x="80" y="80" width="200" height="480" rx="60" fill="#b6763c" />
+    <rect x="360" y="120" width="220" height="440" rx="72" fill="#b6763c" opacity="0.92" />
+    <rect x="230" y="340" width="140" height="220" rx="48" fill="#874e24" opacity="0.7" />
+    <path d="M120 240 C 200 180, 160 120, 200 80" fill="none" stroke="#f3c485" stroke-width="22" stroke-linecap="round" opacity="0.7" />
+    <path d="M410 220 C 470 170, 490 240, 520 200" fill="none" stroke="#f3c485" stroke-width="20" stroke-linecap="round" opacity="0.65" />
+    <path d="M160 420 Q 220 360 260 420" fill="none" stroke="#874e24" stroke-width="24" stroke-linecap="round" opacity="0.75" />
+    <circle cx="180" cy="220" r="24" fill="#fff6e8" opacity="0.75" />
+    <circle cx="220" cy="220" r="24" fill="#fff6e8" opacity="0.65" />
+    <circle cx="430" cy="250" r="26" fill="#fff6e8" opacity="0.7" />
+    <circle cx="470" cy="250" r="26" fill="#fff6e8" opacity="0.6" />
+    <path d="M390 420 Q 450 360 510 420" fill="none" stroke="#874e24" stroke-width="24" stroke-linecap="round" opacity="0.7" />
+  </g>
+</svg>

--- a/assets/woodwork/carving-8.svg
+++ b/assets/woodwork/carving-8.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="wood-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f7eddc" />
+      <stop offset="100%" stop-color="#e4c89b" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#wood-bg)" />
+  <g transform="translate(160 140)">
+    <rect x="80" y="80" width="200" height="480" rx="60" fill="#ca9152" />
+    <rect x="360" y="120" width="220" height="440" rx="72" fill="#ca9152" opacity="0.92" />
+    <rect x="230" y="340" width="140" height="220" rx="48" fill="#a36c35" opacity="0.7" />
+    <path d="M120 240 C 200 180, 160 120, 200 80" fill="none" stroke="#fbe0a7" stroke-width="22" stroke-linecap="round" opacity="0.7" />
+    <path d="M410 220 C 470 170, 490 240, 520 200" fill="none" stroke="#fbe0a7" stroke-width="20" stroke-linecap="round" opacity="0.65" />
+    <path d="M160 420 Q 220 360 260 420" fill="none" stroke="#a36c35" stroke-width="24" stroke-linecap="round" opacity="0.75" />
+    <circle cx="180" cy="220" r="24" fill="#fff6e8" opacity="0.75" />
+    <circle cx="220" cy="220" r="24" fill="#fff6e8" opacity="0.65" />
+    <circle cx="430" cy="250" r="26" fill="#fff6e8" opacity="0.7" />
+    <circle cx="470" cy="250" r="26" fill="#fff6e8" opacity="0.6" />
+    <path d="M390 420 Q 450 360 510 420" fill="none" stroke="#a36c35" stroke-width="24" stroke-linecap="round" opacity="0.7" />
+  </g>
+</svg>

--- a/assets/woodwork/carving-9.svg
+++ b/assets/woodwork/carving-9.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="wood-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f5ebd8" />
+      <stop offset="100%" stop-color="#e0c39b" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="900" fill="url(#wood-bg)" />
+  <g transform="translate(160 140)">
+    <rect x="80" y="80" width="200" height="480" rx="60" fill="#bd7f3a" />
+    <rect x="360" y="120" width="220" height="440" rx="72" fill="#bd7f3a" opacity="0.92" />
+    <rect x="230" y="340" width="140" height="220" rx="48" fill="#945824" opacity="0.7" />
+    <path d="M120 240 C 200 180, 160 120, 200 80" fill="none" stroke="#f2c885" stroke-width="22" stroke-linecap="round" opacity="0.7" />
+    <path d="M410 220 C 470 170, 490 240, 520 200" fill="none" stroke="#f2c885" stroke-width="20" stroke-linecap="round" opacity="0.65" />
+    <path d="M160 420 Q 220 360 260 420" fill="none" stroke="#945824" stroke-width="24" stroke-linecap="round" opacity="0.75" />
+    <circle cx="180" cy="220" r="24" fill="#fff6e8" opacity="0.75" />
+    <circle cx="220" cy="220" r="24" fill="#fff6e8" opacity="0.65" />
+    <circle cx="430" cy="250" r="26" fill="#fff6e8" opacity="0.7" />
+    <circle cx="470" cy="250" r="26" fill="#fff6e8" opacity="0.6" />
+    <path d="M390 420 Q 450 360 510 420" fill="none" stroke="#945824" stroke-width="24" stroke-linecap="round" opacity="0.7" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,510 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hobby Kollector | Multidisciplinary Hobby Studio</title>
+  <meta name="description" content="Hobby Kollector chronicles a multi-passion artist exploring ceramics, stickers, wood carvings, painting, and digital stencil assets." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;600;700&family=Urbanist:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="logo" aria-label="Hobby Kollector home">
+      <span class="logo-mark">HK</span>
+      <span class="logo-type">Hobby Kollector</span>
+    </div>
+    <nav class="primary-nav" aria-label="Primary">
+      <ul class="nav-list">
+        <li>
+          <a class="nav-link" href="#ceramics">
+            <span class="nav-icon" aria-hidden="true">
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M6 4h20l-2 12a8 8 0 01-7 6.9V28h4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M16 22.9A8 8 0 019 16L7 4h18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <span class="nav-text">Ceramics</span>
+          </a>
+        </li>
+        <li>
+          <a class="nav-link" href="#stickers">
+            <span class="nav-icon" aria-hidden="true">
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M10 5h12a3 3 0 013 3v12a7 7 0 01-7 7H9a2 2 0 01-2-2V10a5 5 0 015-5z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M18 27v-6a3 3 0 00-3-3H9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </span>
+            <span class="nav-text">Stickers</span>
+          </a>
+        </li>
+        <li>
+          <a class="nav-link" href="#woodwork">
+            <span class="nav-icon" aria-hidden="true">
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M6 17l5 11h10l5-11" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M11 17V4h10v13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M14 8h4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            </span>
+            <span class="nav-text">Woodwork</span>
+          </a>
+        </li>
+        <li>
+          <a class="nav-link" href="#painting">
+            <span class="nav-icon" aria-hidden="true">
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M18.8 4.2C12.7 4.2 7.7 8.9 7.7 14.7S12 25 17.6 25h1c1.6 0 2.8-1.2 2.8-2.7 0-1-.8-1.8-1.8-1.8-3.7 0-6.8-2.9-6.8-6.4s3.6-6.4 7.3-6.4c4.4 0 7.9 3.3 7.9 7.6 0 3.4-2.6 6.2-6 6.8" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="13" cy="11.5" r="1.5" fill="currentColor"/><circle cx="20.5" cy="9.5" r="1.2" fill="currentColor"/><circle cx="23.5" cy="13.2" r="1" fill="currentColor"/><circle cx="15.4" cy="16" r="1.1" fill="currentColor"/></svg>
+            </span>
+            <span class="nav-text">Painting</span>
+          </a>
+        </li>
+        <li>
+          <a class="nav-link" href="#digital">
+            <span class="nav-icon" aria-hidden="true">
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><rect x="5" y="6" width="22" height="16" rx="3" ry="3" fill="none" stroke="currentColor" stroke-width="2"/><path d="M12 26h8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            </span>
+            <span class="nav-text">Digital Assets</span>
+          </a>
+        </li>
+        <li>
+          <a class="nav-link" href="#gallery">
+            <span class="nav-icon" aria-hidden="true">
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><rect x="4" y="7" width="24" height="18" rx="3" ry="3" fill="none" stroke="currentColor" stroke-width="2"/><path d="M10 17l4-4 4 4 4-3 4 4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/></svg>
+            </span>
+            <span class="nav-text">Gallery</span>
+          </a>
+        </li>
+      </ul>
+    </nav>
+    <div class="header-actions">
+      <button class="icon-btn search" type="button" aria-label="Search">
+        <span class="icon-wrapper">
+          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="11" cy="11" r="6" fill="none" stroke="currentColor" stroke-width="2"/><line x1="16" y1="16" x2="21" y2="21" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+        </span>
+      </button>
+      <a class="icon-btn contact" href="mailto:hello@hobbykollector.com" aria-label="Contact me">
+        <span class="icon-wrapper">
+          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M3.5 6.5h17a1.5 1.5 0 011.5 1.5v8a2 2 0 01-2 2h-16a2 2 0 01-2-2v-8a1.5 1.5 0 011.5-1.5z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M4.5 8l7.5 5 7.5-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </span>
+      </a>
+      <button class="icon-btn cart" type="button" aria-label="Shopping cart">
+        <span class="icon-wrapper">
+          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="9" cy="21" r="1.5" fill="currentColor"/><circle cx="18" cy="21" r="1.5" fill="currentColor"/><path d="M3 5h2l2 11h12l2-7H7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </span>
+      </button>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero" id="top">
+      <div class="hero-copy">
+        <p class="eyebrow">Multidisciplinary studio · One artist, many hobbies</p>
+        <h1>A living archive of the hobbies I'm learning and loving.</h1>
+        <p class="hero-description">Explore the evolving practice of a hobby collector at heart—wheel-thrown ceramics, illustrated stickers, hand-carved wood minis, color-drenched canvases, and digital stencil kits crafted to share the joy of making.</p>
+        <div class="cta-group">
+          <a class="cta primary" href="#ceramics">Explore Mediums</a>
+          <a class="cta secondary" href="#gallery">See the Gallery</a>
+        </div>
+        <dl class="hero-stats">
+          <div>
+            <dt>Mediums in rotation</dt>
+            <dd>5</dd>
+          </div>
+          <div>
+            <dt>Sketchbooks filled</dt>
+            <dd>18</dd>
+          </div>
+          <div>
+            <dt>Studio hours each week</dt>
+            <dd>32</dd>
+          </div>
+        </dl>
+      </div>
+      <div class="hero-media">
+        <div class="hero-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=900&q=80" alt="Handcrafted ceramic vase with celestial glaze" class="active" />
+            <img src="https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=900&q=80" alt="Ceramic artisan shaping clay on a wheel" />
+            <img src="https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=900&q=80" alt="Table with multiple ceramic bowls and cups" />
+          </div>
+        </div>
+        <div class="hero-note">
+          <h2>New Series · Aurora Brushscapes</h2>
+          <p>Layered watercolor and acrylic washes that echo the same gradients I chase in glaze tests—each canvas is a study in motion.</p>
+          <a class="ghost-link" href="#painting">Peek at the canvases</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="category" id="ceramics">
+      <div class="section-header">
+        <div>
+          <p class="section-kicker">Ceramics</p>
+          <h2>Hand-thrown forms for everyday rituals</h2>
+        </div>
+        <a class="section-link" href="#gallery">See more ceramics</a>
+      </div>
+      <div class="product-grid">
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=900&q=80" alt="Celestial blue ceramic vase" class="active" />
+            <img src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=80" alt="Glazed ceramic vases displayed together" />
+            <img src="https://images.unsplash.com/photo-1462396881884-de2c07cb95ed?auto=format&fit=crop&w=900&q=80" alt="Close-up of ceramic glaze details" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Small batch</span>
+            <h3>Celestial Bloom Vessel</h3>
+            <p>Hand-thrown porcelain with layered nebula glazes and gilded rim.</p>
+            <div class="product-meta">
+              <span class="price">$145</span>
+              <span class="availability">12 editions</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=900&q=80" alt="Stack of ceramic plates in earth tones" class="active" />
+            <img src="https://images.unsplash.com/photo-1451471016731-e963a8588be8?auto=format&fit=crop&w=900&q=80" alt="Artist painting ceramic plates" />
+            <img src="https://images.unsplash.com/photo-1522780550605-98e7b380d0bc?auto=format&fit=crop&w=900&q=80" alt="Ceramic plates with brush stroke patterns" />
+          </div>
+          <div class="product-info">
+            <span class="pill accent">Glaze study</span>
+            <h3>Earthbound Dinner Set</h3>
+            <p>Eight-piece stoneware set brushed with gradient washes pulled from my painting palette.</p>
+            <div class="product-meta">
+              <span class="price">$260</span>
+              <span class="availability">Made to order</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1551218808-94e220e084d2?auto=format&fit=crop&w=900&q=80" alt="Minimal ceramic mugs on a table" class="active" />
+            <img src="https://images.unsplash.com/photo-1481349518771-20055b2a7b24?auto=format&fit=crop&w=900&q=80" alt="Ceramic mugs arranged on a shelf" />
+            <img src="https://images.unsplash.com/photo-1510906594845-bc082582c8cc?auto=format&fit=crop&w=900&q=80" alt="Pair of ceramic cups with gradient glaze" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Studio exclusive</span>
+            <h3>Mist Horizon Cup Duo</h3>
+            <p>Soft gradient mugs with ergonomic handles and luminous sheen.</p>
+            <div class="product-meta">
+              <span class="price">$88</span>
+              <span class="availability">Set of two</span>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="category" id="stickers">
+      <div class="section-header">
+        <div>
+          <p class="section-kicker">Stickers</p>
+          <h2>Illustrated stories that stick with you</h2>
+        </div>
+        <a class="section-link" href="#gallery">Shop sticker packs</a>
+      </div>
+      <div class="product-grid">
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=900&q=80" alt="Hands sorting through illustrated stickers" class="active" />
+            <img src="https://images.unsplash.com/photo-1512436991641-6745cdb1723f?auto=format&fit=crop&w=900&q=80" alt="Sticker sheet with colorful illustrations" />
+            <img src="https://images.unsplash.com/photo-1529335764857-3f1164d1cb24?auto=format&fit=crop&w=900&q=80" alt="Sticker pack spread across a desk" />
+          </div>
+          <div class="product-info">
+            <span class="pill">New artist</span>
+            <h3>Daydreamer Decals</h3>
+            <p>Whimsical characters exploring starry skies and cozy studios.</p>
+            <div class="product-meta">
+              <span class="price">$18</span>
+              <span class="availability">Pack of 12</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1513364776144-60967b0f800f?auto=format&fit=crop&w=900&q=80" alt="Sticker-filled journal with neon accents" class="active" />
+            <img src="https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=900&q=80" alt="Close-up of holographic stickers" />
+            <img src="https://images.unsplash.com/photo-1531482615713-2afd69097998?auto=format&fit=crop&w=900&q=80" alt="Sticker sheet featuring modern shapes" />
+          </div>
+          <div class="product-info">
+            <span class="pill accent">Holographic</span>
+            <h3>Neon Pulse Sheets</h3>
+            <p>Layered neon gradients with iridescent overlays for journals and tech.</p>
+            <div class="product-meta">
+              <span class="price">$22</span>
+              <span class="availability">Limited run</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1502741338009-cac2772e18bc?auto=format&fit=crop&w=900&q=80" alt="Sticker pack featuring nature illustrations" class="active" />
+            <img src="https://images.unsplash.com/photo-1529333166433-7750a6dd5a70?auto=format&fit=crop&w=900&q=80" alt="Person peeling a sticker off a sheet" />
+            <img src="https://images.unsplash.com/photo-1521587760476-6c12a4b040da?auto=format&fit=crop&w=900&q=80" alt="Sticker sheets arranged on a table" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Eco inks</span>
+            <h3>Wander Wild Pack</h3>
+            <p>Botanical illustrations printed on recycled matte stock.</p>
+            <div class="product-meta">
+              <span class="price">$16</span>
+              <span class="availability">Set of 10</span>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="category" id="woodwork">
+      <div class="section-header">
+        <div>
+          <p class="section-kicker">Wood carving</p>
+          <h2>Hand-carved minis and heirloom keepsakes</h2>
+        </div>
+        <a class="section-link" href="#gallery">Browse wood carvings</a>
+      </div>
+      <div class="product-grid">
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="assets/woodwork/carving-1.svg" alt="Pair of hand-carved wooden totems with smooth finish" class="active" />
+            <img src="assets/woodwork/carving-2.svg" alt="Close-up of carved wood grain patterns on pocket totems" />
+            <img src="assets/woodwork/carving-3.svg" alt="Detail of hand-burnished wood miniatures" />
+          </div>
+          <div class="product-info">
+            <span class="pill accent">Whittled duo</span>
+            <h3>Pocket Totem Pair</h3>
+            <p>Carved alder keepsakes sealed with beeswax to match my watercolor palettes.</p>
+            <div class="product-meta">
+              <span class="price">$78</span>
+              <span class="availability">Set of two</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="assets/woodwork/carving-4.svg" alt="Hand-carved lidded box with rounded profile" class="active" />
+            <img src="assets/woodwork/carving-5.svg" alt="Open view of carved keepsake box showing interior" />
+            <img src="assets/woodwork/carving-6.svg" alt="Detail of wood-burned constellations inside the box" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Hidden storage</span>
+            <h3>Constellation Keepsake Box</h3>
+            <p>Small cedar box with wood-burned stars that cradle sticker packs and mini tools.</p>
+            <div class="product-meta">
+              <span class="price">$120</span>
+              <span class="availability">3" x 5" x 3"</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="assets/woodwork/carving-7.svg" alt="Carved wooden companions with carved smiles" class="active" />
+            <img src="assets/woodwork/carving-8.svg" alt="Process view of shaping wooden companions" />
+            <img src="assets/woodwork/carving-9.svg" alt="Group of mini carvings lined up on a workbench" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Desk buddies</span>
+            <h3>Orbit Companion Trio</h3>
+            <p>Three hand-carved figures finished with milk paint accents and satin oil.</p>
+            <div class="product-meta">
+              <span class="price">$98</span>
+              <span class="availability">Set of three</span>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="category" id="painting">
+      <div class="section-header">
+        <div>
+          <p class="section-kicker">Painting</p>
+          <h2>Watercolor and acrylic stories on canvas</h2>
+        </div>
+        <a class="section-link" href="#gallery">See all paintings</a>
+      </div>
+      <div class="product-grid">
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="assets/painting/brushscape-1.svg" alt="Watercolor canvas with indigo and coral washes" class="active" />
+            <img src="assets/painting/brushscape-2.svg" alt="Process photo of layered watercolor gradients" />
+            <img src="assets/painting/brushscape-3.svg" alt="Detail of shimmering gouache strokes on canvas" />
+          </div>
+          <div class="product-info">
+            <span class="pill accent">Watercolor study</span>
+            <h3>Aurora Drift Canvas</h3>
+            <p>Transparent watercolor and pearlescent gouache blended to echo the glow of crystal glazes.</p>
+            <div class="product-meta">
+              <span class="price">$180</span>
+              <span class="availability">16 x 20 in.</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="assets/painting/brushscape-4.svg" alt="Acrylic painting with sweeping violet strokes" class="active" />
+            <img src="assets/painting/brushscape-5.svg" alt="Layered acrylic textures in warm gradients" />
+            <img src="assets/painting/brushscape-6.svg" alt="Palette knife marks building bold highlights" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Acrylic layers</span>
+            <h3>Chromatic Threshold Diptych</h3>
+            <p>Two-panel acrylic series exploring the same color stories as my carved wood stains.</p>
+            <div class="product-meta">
+              <span class="price">$320</span>
+              <span class="availability">Pair of 12 x 16 in.</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="assets/painting/brushscape-7.svg" alt="Mixed-media canvas with deep teal shadows" class="active" />
+            <img src="assets/painting/brushscape-8.svg" alt="Sketchbook scan translating into canvas composition" />
+            <img src="assets/painting/brushscape-9.svg" alt="Detail of layered shadow stencils on canvas" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Mixed media</span>
+            <h3>Midnight Garden Study</h3>
+            <p>Watercolor, pencil, and shadow stencils mapped onto stretched canvas with archival varnish.</p>
+            <div class="product-meta">
+              <span class="price">$240</span>
+              <span class="availability">Ready to hang</span>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="category" id="digital">
+      <div class="section-header">
+        <div>
+          <p class="section-kicker">Digital Assets</p>
+          <h2>Shadow stencil kits for hybrid makers</h2>
+        </div>
+        <a class="section-link" href="#gallery">Open the digital vault</a>
+      </div>
+      <div class="product-grid">
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="assets/digital/stencil-1.svg" alt="Digital tablet displaying layered shadow stencils" class="active" />
+            <img src="assets/digital/stencil-2.svg" alt="Shadow stencil overlays arranged for export" />
+            <img src="assets/digital/stencil-3.svg" alt="Color-coded stencil masks ready for illustration" />
+          </div>
+          <div class="product-info">
+            <span class="pill accent">Stencil suite</span>
+            <h3>Shadow Storyboard Toolkit</h3>
+            <p>40 Procreate and PSD stencils that map lighting for ceramics, wood carvings, and canvas studies.</p>
+            <div class="product-meta">
+              <span class="price">$46</span>
+              <span class="availability">Instant download</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="assets/digital/stencil-4.svg" alt="Desktop monitor mockup with luminous shadow stencils" class="active" />
+            <img src="assets/digital/stencil-5.svg" alt="Collection of gradient shadow overlays for export" />
+            <img src="assets/digital/stencil-6.svg" alt="Vector stencil pack featuring layered highlights" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Lighting presets</span>
+            <h3>Luminous Shadow Library</h3>
+            <p>High-res PNG and SVG overlays crafted from my painting light studies for fast scene building.</p>
+            <div class="product-meta">
+              <span class="price">$52</span>
+              <span class="availability">Commercial use</span>
+            </div>
+          </div>
+        </article>
+        <article class="product-card hover-carousel">
+          <div class="media-stack">
+            <img src="assets/digital/stencil-7.svg" alt="Shadow stencil planner interface on dark canvas" class="active" />
+            <img src="assets/digital/stencil-8.svg" alt="Workflow board arranging stencil sets" />
+            <img src="assets/digital/stencil-9.svg" alt="Bundle of nocturne-inspired shadow masks" />
+          </div>
+          <div class="product-info">
+            <span class="pill">Workflow</span>
+            <h3>Nocturne Overlay Pack</h3>
+            <p>Notion planner and transparent overlays to script lighting sequences across mediums.</p>
+            <div class="product-meta">
+              <span class="price">$38</span>
+              <span class="availability">Bundle</span>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="gallery" id="gallery">
+      <div class="section-header">
+        <div>
+          <p class="section-kicker">Gallery</p>
+          <h2>Crystal glaze close-ups</h2>
+        </div>
+        <a class="section-link" href="#top">Back to top</a>
+      </div>
+      <div class="gallery-grid">
+        <figure class="gallery-item hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1462396881884-de2c07cb95ed?auto=format&fit=crop&w=900&q=80" alt="Macro of crystal glaze pooling on a ceramic vase" class="active" />
+            <img src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=900&q=80" alt="Faceted blue vase catching light" />
+            <img src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=900&q=80" alt="Stacked plates with crystalline glazes" />
+          </div>
+          <figcaption>Testing nebula-inspired crystals on wheel-thrown forms.</figcaption>
+        </figure>
+        <figure class="gallery-item hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1551218808-94e220e084d2?auto=format&fit=crop&w=900&q=80" alt="Set of mugs with frosted crystal interiors" class="active" />
+            <img src="https://images.unsplash.com/photo-1481349518771-20055b2a7b24?auto=format&fit=crop&w=900&q=80" alt="Shelf of glossy mugs fresh from the kiln" />
+            <img src="https://images.unsplash.com/photo-1510906594845-bc082582c8cc?auto=format&fit=crop&w=900&q=80" alt="Close-up of a crystalline mug rim" />
+          </div>
+          <figcaption>Mugs fired with layered glazes that break into icy blooms.</figcaption>
+        </figure>
+        <figure class="gallery-item hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1522780550605-98e7b380d0bc?auto=format&fit=crop&w=900&q=80" alt="Brushstroke glazing on shallow bowls" class="active" />
+            <img src="https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=900&q=80" alt="Ceramic vessels shimmering with crystal specks" />
+            <img src="https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=900&q=80" alt="Artist applying glaze splashes to pottery" />
+          </div>
+          <figcaption>Glaze experiments that echo my watercolor gradients.</figcaption>
+        </figure>
+        <figure class="gallery-item hover-carousel">
+          <div class="media-stack">
+            <img src="https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=900&q=80" alt="Display of crystal-glazed vessels on studio shelving" class="active" />
+            <img src="https://images.unsplash.com/photo-1451471016731-e963a8588be8?auto=format&fit=crop&w=900&q=80" alt="Hand adding brushwork to a crystal glaze" />
+            <img src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=900&q=80&sat=-20" alt="Detail of crystalline highlights under soft light" />
+          </div>
+          <figcaption>Studio shelves of finished pieces ready for hobby swaps.</figcaption>
+        </figure>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="footer-grid">
+      <div>
+        <div class="logo footer-logo">
+          <span class="logo-mark">HK</span>
+          <span class="logo-type">Hobby Kollector</span>
+        </div>
+        <p>Notes from a hobby collector exploring clay, pigment, wood shavings, and pixels. Join the drop list to swap tips on the next experiment.</p>
+      </div>
+      <div>
+        <h3>Visit</h3>
+        <p>1024 Aurora Lane<br />Portland, OR 97205</p>
+      </div>
+      <div>
+        <h3>Contact</h3>
+        <ul>
+          <li><a href="mailto:hello@hobbykollector.com">hello@hobbykollector.com</a></li>
+          <li><a href="tel:+15035551234">+1 (503) 555-1234</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Follow</h3>
+        <ul class="social-list">
+          <li><a href="#">Instagram</a></li>
+          <li><a href="#">Pinterest</a></li>
+          <li><a href="#">Behance</a></li>
+        </ul>
+      </div>
+    </div>
+    <p class="footer-note">© <span id="year"></span> Hobby Kollector. All rights reserved.</p>
+  </footer>
+
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,134 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const yearField = document.getElementById('year');
+  if (yearField) {
+    yearField.textContent = new Date().getFullYear();
+  }
+
+  document.body.classList.add('scroll-animations');
+
+  const iconButtons = document.querySelectorAll('.icon-btn');
+  iconButtons.forEach((button) => {
+    const wrapper = button.querySelector('.icon-wrapper');
+    if (!wrapper) return;
+
+    let rafId = null;
+
+    const animateTo = (x, y) => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        const pullStrength = 0.32;
+        wrapper.style.transform = `translate(${x * pullStrength}px, ${y * pullStrength}px)`;
+      });
+    };
+
+    const handleMove = (event) => {
+      const rect = button.getBoundingClientRect();
+      const offsetX = event.clientX - rect.left - rect.width / 2;
+      const offsetY = event.clientY - rect.top - rect.height / 2;
+      animateTo(offsetX, offsetY);
+    };
+
+    const reset = () => {
+      cancelAnimationFrame(rafId);
+      wrapper.style.transform = 'translate(0, 0)';
+    };
+
+    button.addEventListener('mousemove', handleMove);
+    button.addEventListener('mouseenter', (event) => {
+      if (event.clientX && event.clientY) {
+        handleMove(event);
+      }
+    });
+    button.addEventListener('mouseleave', reset);
+    button.addEventListener('blur', reset);
+    button.addEventListener('touchstart', reset, { passive: true });
+  });
+
+  const observerOptions = {
+    threshold: 0.2,
+    rootMargin: '0px 0px -10% 0px'
+  };
+
+  const revealElements = () => {
+    const images = document.querySelectorAll('img');
+    images.forEach((img) => {
+      img.classList.add('reveal-on-scroll');
+    });
+
+    if ('IntersectionObserver' in window) {
+      const revealObserver = new IntersectionObserver((entries, obs) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-visible');
+            obs.unobserve(entry.target);
+          }
+        });
+      }, observerOptions);
+
+      images.forEach((img) => revealObserver.observe(img));
+    } else {
+      images.forEach((img) => img.classList.add('is-visible'));
+    }
+  };
+
+  revealElements();
+
+  const supportsHover = window.matchMedia('(hover: hover) and (pointer: fine)').matches;
+
+  const carouselContainers = document.querySelectorAll('.hover-carousel');
+  carouselContainers.forEach((container) => {
+    const stack = container.querySelector('.media-stack');
+    if (!stack) return;
+    const slides = Array.from(stack.querySelectorAll('img'));
+    if (slides.length <= 1) return;
+
+    let index = 0;
+    let intervalId = null;
+    let startTimer = null;
+
+    const showSlide = (nextIndex) => {
+      slides.forEach((slide, idx) => {
+        slide.classList.toggle('active', idx === nextIndex);
+      });
+    };
+
+    const startCarousel = () => {
+      if (intervalId) return;
+      container.classList.add('carousel-active');
+      startTimer = setTimeout(() => {
+        intervalId = setInterval(() => {
+          index = (index + 1) % slides.length;
+          showSlide(index);
+        }, 1200);
+      }, 180);
+    };
+
+    const stopCarousel = () => {
+      container.classList.remove('carousel-active');
+      clearTimeout(startTimer);
+      startTimer = null;
+      if (intervalId) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+      index = 0;
+      showSlide(index);
+    };
+
+    if (supportsHover) {
+      container.addEventListener('mouseenter', startCarousel);
+      container.addEventListener('mouseleave', stopCarousel);
+      container.addEventListener('focusin', startCarousel);
+      container.addEventListener('focusout', stopCarousel);
+    } else {
+      container.addEventListener('click', () => {
+        index = (index + 1) % slides.length;
+        showSlide(index);
+      });
+      container.addEventListener('mouseleave', () => {
+        index = 0;
+        showSlide(index);
+      });
+    }
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,677 @@
+:root {
+  --page-gradient: linear-gradient(135deg, #f1ecff 0%, #d9f5f2 45%, #ffe7f3 100%);
+  --text-color: #1f2133;
+  --muted-text: #5f6478;
+  --surface: rgba(255, 255, 255, 0.72);
+  --surface-strong: rgba(255, 255, 255, 0.92);
+  --surface-line: rgba(255, 255, 255, 0.4);
+  --accent: #6c4bff;
+  --accent-warm: #ff8a65;
+  --accent-cool: #3cc8ab;
+  --accent-soft: rgba(108, 75, 255, 0.14);
+  --shadow-soft: 0 22px 45px rgba(41, 45, 62, 0.16);
+  --shadow-strong: 0 30px 60px rgba(68, 70, 84, 0.22);
+  --radius-lg: 26px;
+  --radius-md: 18px;
+  --radius-pill: 999px;
+  --content-max: 1200px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Urbanist", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--page-gradient);
+  color: var(--text-color);
+  line-height: 1.6;
+  min-height: 100vh;
+  position: relative;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 10% 10%, rgba(108, 75, 255, 0.18), transparent 60%),
+    radial-gradient(circle at 90% 20%, rgba(60, 200, 171, 0.2), transparent 65%),
+    radial-gradient(circle at 15% 80%, rgba(255, 138, 101, 0.18), transparent 55%);
+  pointer-events: none;
+  z-index: -2;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  backdrop-filter: saturate(120%) blur(32px);
+  pointer-events: none;
+  z-index: -1;
+}
+
+main {
+  padding: 5rem min(6vw, 80px) 7rem;
+}
+
+h1,
+ h2,
+ h3,
+ h4 {
+  font-family: "Playfair Display", "Times New Roman", serif;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: #16182b;
+}
+
+p {
+  margin-top: 0.4rem;
+  margin-bottom: 1rem;
+  color: var(--muted-text);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+ a:focus-visible {
+  color: var(--accent);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.15rem min(6vw, 80px);
+  background: rgba(248, 246, 255, 0.82);
+  backdrop-filter: blur(18px) saturate(140%);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 18px 35px rgba(88, 90, 104, 0.12);
+}
+
+.logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-weight: 600;
+  font-size: 1.05rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #151728;
+}
+
+.logo-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  border-radius: 0.8rem;
+  background: linear-gradient(135deg, #6c4bff 0%, #3cc8ab 100%);
+  color: #fff;
+  font-size: 1.1rem;
+  font-weight: 700;
+  box-shadow: 0 12px 24px rgba(108, 75, 255, 0.32);
+}
+
+.primary-nav {
+  flex: 1;
+}
+
+.nav-list {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin: 0;
+  padding: 0;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.6rem 0.95rem;
+  border-radius: var(--radius-pill);
+  color: #373b50;
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  transition: color 0.3s ease, background 0.35s ease, box-shadow 0.35s ease, transform 0.35s ease;
+}
+
+.nav-link .nav-icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  transition: color 0.3s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus-visible {
+  background: linear-gradient(135deg, rgba(108, 75, 255, 0.18), rgba(60, 200, 171, 0.16));
+  color: #17192c;
+  box-shadow: 0 12px 26px rgba(76, 96, 163, 0.25);
+  transform: translateY(-2px);
+}
+
+.nav-link:hover .nav-icon svg,
+.nav-link:focus-visible .nav-icon svg {
+  color: var(--accent);
+}
+
+.nav-link:focus-visible {
+  outline: 2px solid rgba(108, 75, 255, 0.4);
+  outline-offset: 2px;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.icon-btn {
+  position: relative;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 1.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  background: var(--surface-strong);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+  transition: box-shadow 0.45s cubic-bezier(0.33, 1, 0.68, 1), transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
+  overflow: hidden;
+}
+
+.icon-btn:hover,
+.icon-btn:focus-visible {
+  box-shadow: var(--shadow-soft);
+  transform: translateY(-1px);
+}
+
+.icon-btn:focus-visible {
+  outline: 2px solid rgba(108, 75, 255, 0.4);
+  outline-offset: 2px;
+}
+
+.icon-wrapper {
+  display: inline-flex;
+  transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.icon-btn svg {
+  width: 1.4rem;
+  height: 1.4rem;
+  color: #1f2133;
+  pointer-events: none;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(2rem, 5vw, 4rem);
+  align-items: center;
+  margin-top: 3.5rem;
+  margin-bottom: 5rem;
+}
+
+.hero-copy {
+  max-width: 520px;
+}
+
+.hero-copy .eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.35em;
+  font-weight: 600;
+  color: rgba(55, 59, 80, 0.7);
+  margin-bottom: 1.5rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 5vw, 3.4rem);
+  margin-bottom: 1.2rem;
+}
+
+.hero-description {
+  font-size: 1.05rem;
+  color: #495067;
+}
+
+.cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+  margin: 2.1rem 0;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.6rem;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.cta.primary {
+  background: linear-gradient(135deg, #6c4bff 0%, #3cc8ab 100%);
+  color: #fff;
+  box-shadow: 0 16px 35px rgba(108, 75, 255, 0.35);
+}
+
+.cta.primary:hover,
+.cta.primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-strong);
+}
+
+.cta.secondary {
+  background: rgba(255, 255, 255, 0.65);
+  color: #1f2133;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.cta.secondary:hover,
+.cta.secondary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-soft);
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1.2rem;
+  margin: 2.5rem 0 0;
+}
+
+.hero-stats div {
+  background: rgba(255, 255, 255, 0.55);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.3rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.hero-stats dt {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  color: rgba(55, 59, 80, 0.7);
+  margin-bottom: 0.4rem;
+}
+
+.hero-stats dd {
+  margin: 0;
+  font-family: "Playfair Display", serif;
+  font-size: 1.6rem;
+  color: #1f2133;
+}
+
+.hero-media {
+  position: relative;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero-card .media-stack {
+  aspect-ratio: 3 / 4;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0.55));
+}
+
+.hero-note {
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  border-radius: var(--radius-lg);
+  padding: 1.6rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.hero-note h2 {
+  font-size: 1.35rem;
+  margin: 0 0 0.6rem;
+}
+
+.hero-note p {
+  margin-bottom: 1rem;
+}
+
+.ghost-link {
+  color: var(--accent);
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.ghost-link::after {
+  content: "→";
+  transition: transform 0.3s ease;
+}
+
+.ghost-link:hover::after {
+  transform: translateX(4px);
+}
+
+.category,
+.gallery {
+  margin-bottom: 6rem;
+}
+
+.section-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.section-kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(55, 59, 80, 0.7);
+  margin-bottom: 0.7rem;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.6rem);
+}
+
+.section-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  padding: 0.65rem 1.1rem;
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.section-link::after {
+  content: "↗";
+  font-size: 0.9rem;
+}
+
+.section-link:hover,
+.section-link:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(86, 100, 138, 0.18);
+}
+
+.product-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.product-card {
+  background: var(--surface);
+  border: 1px solid var(--surface-line);
+  border-radius: var(--radius-lg);
+  padding: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.3rem;
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.4s cubic-bezier(0.33, 1, 0.68, 1), box-shadow 0.4s cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+.product-card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-strong);
+}
+
+.media-stack {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.45));
+}
+
+.media-stack img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
+  opacity: 0;
+  transform: translateY(24px) scale(0.96);
+  transition: opacity 0.7s cubic-bezier(0.33, 1, 0.68, 1), transform 0.7s cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+.media-stack img.active {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  z-index: 1;
+}
+
+.product-info h3 {
+  font-size: 1.3rem;
+  margin: 0 0 0.6rem;
+}
+
+.product-info p {
+  margin: 0 0 1.1rem;
+}
+
+.product-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  color: #252942;
+}
+
+.price {
+  font-size: 1.1rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.45rem 0.85rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  background: rgba(60, 200, 171, 0.16);
+  color: #157c68;
+  font-weight: 700;
+}
+
+.pill.accent {
+  background: rgba(108, 75, 255, 0.18);
+  color: #5232d2;
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 2rem;
+}
+
+.gallery-item {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: 1.4rem;
+  border: 1px solid var(--surface-line);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  transition: transform 0.4s cubic-bezier(0.33, 1, 0.68, 1), box-shadow 0.4s cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+.gallery-item:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-strong);
+}
+
+.gallery-item figcaption {
+  font-size: 0.95rem;
+  color: #40445c;
+}
+
+.site-footer {
+  padding: 4rem min(6vw, 80px) 2rem;
+  background: rgba(248, 246, 255, 0.88);
+  border-top: 1px solid rgba(255, 255, 255, 0.6);
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.footer-grid p,
+.footer-grid a {
+  color: #454a61;
+}
+
+.footer-grid h3 {
+  margin-top: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.footer-grid ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.social-list a:hover {
+  color: var(--accent);
+}
+
+.footer-note {
+  text-align: center;
+  font-size: 0.85rem;
+  color: rgba(55, 59, 80, 0.66);
+}
+
+/* Reveal animation */
+
+body.scroll-animations .reveal-on-scroll {
+  opacity: 0;
+  transform: translateY(24px) scale(0.96);
+}
+
+body.scroll-animations .reveal-on-scroll.is-visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  transition: opacity 0.7s cubic-bezier(0.33, 1, 0.68, 1), transform 0.7s cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+.hover-carousel.carousel-active .media-stack img {
+  transition-duration: 0.45s;
+}
+
+/* Responsive adjustments */
+
+@media (max-width: 960px) {
+  .site-header {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .primary-nav {
+    order: 3;
+    width: 100%;
+  }
+
+  .nav-list {
+    justify-content: flex-start;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+  }
+
+  .header-actions {
+    order: 2;
+  }
+
+  .logo {
+    order: 1;
+  }
+}
+
+@media (max-width: 720px) {
+  main {
+    padding: 4rem min(5vw, 32px) 6rem;
+  }
+
+  .hero {
+    margin-top: 2rem;
+  }
+
+  .hero-stats {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .nav-link {
+    padding: 0.55rem 0.8rem;
+  }
+
+  .icon-btn {
+    width: 2.7rem;
+    height: 2.7rem;
+    border-radius: 1.2rem;
+  }
+
+  .hero-note {
+    padding: 1.3rem;
+  }
+
+  .product-card,
+  .gallery-item {
+    padding: 1.1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  body.scroll-animations .reveal-on-scroll,
+  .media-stack img {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- reword hero, navigation, and footer content to emphasize Hobby Kollector as a multi-medium hobby practice and add a mailto contact icon in the header
- swap the former metalwork area for a painting section and redesign the wood carving and digital asset showcases with custom SVG carousels that match each craft
- refresh the gallery with crystal-glaze pottery imagery and tune copy across sections to reflect the updated focus

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc21402880832aac52dd4a28e59ac5