### PR TITLE
Reword site copy to highlight collected hobbies and add painting section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,17 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Hobby Kollector | Modern Handmade Collectibles</title>
-  <meta name="description" content="Hobby Kollector is your destination for handcrafted ceramics, stickers, woodwork, metalwork, and digital assets." />
+  <title>Hobby Kollector | A Studio of Collected Hobbies</title>
+  <meta
+    name="description"
+    content="Hobby Kollector documents one artist's collection of hobbies—from ceramics and stickers to woodwork, painting, and digital experiments."
+  />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;600;700&family=Urbanist:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;600;700&family=Urbanist:wght@300;400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
@@ -21,7 +27,23 @@
         <li>
           <a class="nav-link" href="#ceramics">
             <span class="nav-icon" aria-hidden="true">
-              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M6 4h20l-2 12a8 8 0 01-7 6.9V28h4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M16 22.9A8 8 0 019 16L7 4h18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"
+                ><path
+                  d="M6 4h20l-2 12a8 8 0 01-7 6.9V28h4"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                /><path
+                  d="M16 22.9A8 8 0 019 16L7 4h18"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                /></svg
+              >
             </span>
             <span class="nav-text">Ceramics</span>
           </a>
@@ -29,7 +51,23 @@
         <li>
           <a class="nav-link" href="#stickers">
             <span class="nav-icon" aria-hidden="true">
-              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M10 5h12a3 3 0 013 3v12a7 7 0 01-7 7H9a2 2 0 01-2-2V10a5 5 0 015-5z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M18 27v-6a3 3 0 00-3-3H9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"
+                ><path
+                  d="M10 5h12a3 3 0 013 3v12a7 7 0 01-7 7H9a2 2 0 01-2-2V10a5 5 0 015-5z"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                /><path
+                  d="M18 27v-6a3 3 0 00-3-3H9"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                /></svg
+              >
             </span>
             <span class="nav-text">Stickers</span>
           </a>
@@ -37,31 +75,67 @@
         <li>
           <a class="nav-link" href="#woodwork">
             <span class="nav-icon" aria-hidden="true">
-              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M6 17l5 11h10l5-11" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M11 17V4h10v13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M14 8h4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"
+                ><path
+                  d="M6 17l5 11h10l5-11"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                /><path
+                  d="M11 17V4h10v13"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                /><path d="M14 8h4" stroke="currentColor" stroke-width="2" stroke-linecap="round" /></svg
+              >
             </span>
             <span class="nav-text">Woodwork</span>
           </a>
         </li>
         <li>
-          <a class="nav-link" href="#metalwork">
+          <a class="nav-link" href="#painting">
             <span class="nav-icon" aria-hidden="true">
-              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><circle cx="11" cy="12" r="5" fill="none" stroke="currentColor" stroke-width="2"/><circle cx="21" cy="20" r="5" fill="none" stroke="currentColor" stroke-width="2"/><path d="M15 15l2 2 2-2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"
+                ><path
+                  d="M4 27c2.2-5.8 7.6-9.6 13.6-9.1l6.4-6.4a3 3 0 10-4.2-4.2l-6.4 6.4C13 19.7 9 24.5 4 27z"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                /><circle cx="23" cy="9" r="1.5" fill="currentColor" /></svg
+              >
             </span>
-            <span class="nav-text">Metalwork</span>
+            <span class="nav-text">Painting</span>
           </a>
         </li>
         <li>
           <a class="nav-link" href="#digital">
             <span class="nav-icon" aria-hidden="true">
-              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><rect x="5" y="6" width="22" height="16" rx="3" ry="3" fill="none" stroke="currentColor" stroke-width="2"/><path d="M12 26h8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"
+                ><rect x="5" y="6" width="22" height="16" rx="3" ry="3" fill="none" stroke="currentColor" stroke-width="2" /><path d="M12 26h8" stroke="currentColor" stroke-width="2" stroke-linecap="round" /></svg
+              >
             </span>
-            <span class="nav-text">Digital Assets</span>
+            <span class="nav-text">Digital Projects</span>
           </a>
         </li>
         <li>
           <a class="nav-link" href="#gallery">
             <span class="nav-icon" aria-hidden="true">
-              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><rect x="4" y="7" width="24" height="18" rx="3" ry="3" fill="none" stroke="currentColor" stroke-width="2"/><path d="M10 17l4-4 4 4 4-3 4 4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/></svg>
+              <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"
+                ><rect x="4" y="7" width="24" height="18" rx="3" ry="3" fill="none" stroke="currentColor" stroke-width="2" /><path
+                  d="M10 17l4-4 4 4 4-3 4 4"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                /><circle cx="12" cy="12" r="1.5" fill="currentColor" /></svg
+              >
             </span>
             <span class="nav-text">Gallery</span>
           </a>
@@ -69,14 +143,33 @@
       </ul>
     </nav>
     <div class="header-actions">
-      <button class="icon-btn search" type="button" aria-label="Search">
+      <button class="icon-btn search" type="button" aria-label="Search the site">
         <span class="icon-wrapper">
-          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="11" cy="11" r="6" fill="none" stroke="currentColor" stroke-width="2"/><line x1="16" y1="16" x2="21" y2="21" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+            ><circle cx="11" cy="11" r="6" fill="none" stroke="currentColor" stroke-width="2" /><line
+              x1="16"
+              y1="16"
+              x2="21"
+              y2="21"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+            /></svg
+          >
         </span>
       </button>
-      <button class="icon-btn cart" type="button" aria-label="Shopping cart">
+      <button class="icon-btn journal" type="button" aria-label="Open the studio journal">
         <span class="icon-wrapper">
-          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="9" cy="21" r="1.5" fill="currentColor"/><circle cx="18" cy="21" r="1.5" fill="currentColor"/><path d="M3 5h2l2 11h12l2-7H7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+            ><path
+              d="M6 4h9a4 4 0 014 4v12H8a2 2 0 00-2 2V4z"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            /><path d="M14 4v16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" /></svg
+          >
         </span>
       </button>
     </div>
@@ -85,40 +178,52 @@
   <main>
     <section class="hero" id="top">
       <div class="hero-copy">
-        <p class="eyebrow">Limited Edition Finds · Crafted for Collectors</p>
-        <h1>Collectible artistry for every passion project.</h1>
-        <p class="hero-description">Discover an evolving catalog of rare ceramics, illustrated stickers, hand-carved woodwork, expressive metal pieces, and refined digital templates. Every release is curated for makers who love to collect stories.</p>
+        <p class="eyebrow">Creative journeys · One artist, many mediums</p>
+        <h1>Collecting hobbies and giving each one a home.</h1>
+        <p class="hero-description">
+          Follow along as I rotate between wheel-thrown ceramics, illustrated stickers, hand-built woodwork, expressive painting, and digital playgrounds. Hobby Kollector is the archive where every experiment gets its moment.
+        </p>
         <div class="cta-group">
-          <a class="cta primary" href="#ceramics">Explore Collections</a>
-          <a class="cta secondary" href="#gallery">View Gallery</a>
+          <a class="cta primary" href="#ceramics">Explore the studio</a>
+          <a class="cta secondary" href="#gallery">View gallery</a>
         </div>
         <dl class="hero-stats">
           <div>
-            <dt>Artists represented</dt>
-            <dd>28</dd>
+            <dt>Mediums in rotation</dt>
+            <dd>5</dd>
           </div>
           <div>
-            <dt>Limited drops this month</dt>
+            <dt>Projects this season</dt>
+            <dd>14</dd>
+          </div>
+          <div>
+            <dt>Years of tinkering</dt>
             <dd>12</dd>
-          </div>
-          <div>
-            <dt>Collector community</dt>
-            <dd>3.4k</dd>
           </div>
         </dl>
       </div>
       <div class="hero-media">
         <div class="hero-card hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=900&q=80" alt="Handcrafted ceramic vase with celestial glaze" class="active" />
-            <img src="https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=900&q=80" alt="Ceramic artisan shaping clay on a wheel" />
-            <img src="https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=900&q=80" alt="Table with multiple ceramic bowls and cups" />
+            <img
+              src="https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=900&q=80"
+              alt="Handcrafted ceramic vase with celestial glaze"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=900&q=80"
+              alt="Ceramic artisan shaping clay on a wheel"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=900&q=80"
+              alt="Table with multiple ceramic bowls and cups"
+            />
           </div>
         </div>
         <div class="hero-note">
-          <h2>New Drop · Cosmic Clay Series</h2>
-          <p>Organic silhouettes finished with iridescent glazes inspired by nebulae. Each piece is signed and numbered.</p>
-          <a class="ghost-link" href="#ceramics">See the collection</a>
+          <h2>Latest focus · Cosmic Clay Series</h2>
+          <p>Organic silhouettes finished with iridescent glazes inspired by nebulae. Documenting every kiln test and glaze formula.</p>
+          <a class="ghost-link" href="#ceramics">See the workbench</a>
         </div>
       </div>
     </section>
@@ -127,56 +232,86 @@
       <div class="section-header">
         <div>
           <p class="section-kicker">Ceramics</p>
-          <h2>Artisanal forms fired to perfection</h2>
+          <h2>Wheel-thrown experiments in luminous glazes</h2>
         </div>
-        <a class="section-link" href="#gallery">Browse all ceramics</a>
+        <a class="section-link" href="#gallery">See more ceramics</a>
       </div>
       <div class="product-grid">
         <article class="product-card hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=900&q=80" alt="Celestial blue ceramic vase" class="active" />
-            <img src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=80" alt="Glazed ceramic vases displayed together" />
-            <img src="https://images.unsplash.com/photo-1462396881884-de2c07cb95ed?auto=format&fit=crop&w=900&q=80" alt="Close-up of ceramic glaze details" />
+            <img
+              src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=900&q=80"
+              alt="Celestial blue ceramic vase"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=80"
+              alt="Glazed ceramic vases displayed together"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1462396881884-de2c07cb95ed?auto=format&fit=crop&w=900&q=80"
+              alt="Close-up of ceramic glaze details"
+            />
           </div>
           <div class="product-info">
-            <span class="pill">Small batch</span>
+            <span class="pill">Glaze study</span>
             <h3>Celestial Bloom Vessel</h3>
-            <p>Hand-thrown porcelain with layered nebula glazes and gilded rim.</p>
+            <p>Hand-thrown porcelain exploring layered nebula washes and gilded rims.</p>
             <div class="product-meta">
-              <span class="price">$145</span>
-              <span class="availability">12 editions</span>
+              <span class="price">Focus: Iridescent glaze chemistry</span>
+              <span class="availability">Status: In kiln testing</span>
             </div>
           </div>
         </article>
         <article class="product-card hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=900&q=80" alt="Stack of ceramic plates in earth tones" class="active" />
-            <img src="https://images.unsplash.com/photo-1451471016731-e963a8588be8?auto=format&fit=crop&w=900&q=80" alt="Artist painting ceramic plates" />
-            <img src="https://images.unsplash.com/photo-1522780550605-98e7b380d0bc?auto=format&fit=crop&w=900&q=80" alt="Ceramic plates with brush stroke patterns" />
+            <img
+              src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=900&q=80"
+              alt="Stack of ceramic plates in earth tones"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1451471016731-e963a8588be8?auto=format&fit=crop&w=900&q=80"
+              alt="Artist painting ceramic plates"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1522780550605-98e7b380d0bc?auto=format&fit=crop&w=900&q=80"
+              alt="Ceramic plates with brush stroke patterns"
+            />
           </div>
           <div class="product-info">
-            <span class="pill accent">Collectors' pick</span>
+            <span class="pill accent">Process journal</span>
             <h3>Earthbound Dinner Set</h3>
-            <p>Eight-piece stoneware set brushed with matte gradient finishes.</p>
+            <p>Documenting warm stoneware plates brushed with matte gradients.</p>
             <div class="product-meta">
-              <span class="price">$260</span>
-              <span class="availability">Made to order</span>
+              <span class="price">Focus: Family-style tableware</span>
+              <span class="availability">Status: Ongoing series</span>
             </div>
           </div>
         </article>
         <article class="product-card hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1551218808-94e220e084d2?auto=format&fit=crop&w=900&q=80" alt="Minimal ceramic mugs on a table" class="active" />
-            <img src="https://images.unsplash.com/photo-1481349518771-20055b2a7b24?auto=format&fit=crop&w=900&q=80" alt="Ceramic mugs arranged on a shelf" />
-            <img src="https://images.unsplash.com/photo-1510906594845-bc082582c8cc?auto=format&fit=crop&w=900&q=80" alt="Pair of ceramic cups with gradient glaze" />
+            <img
+              src="https://images.unsplash.com/photo-1551218808-94e220e084d2?auto=format&fit=crop&w=900&q=80"
+              alt="Minimal ceramic mugs on a table"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1481349518771-20055b2a7b24?auto=format&fit=crop&w=900&q=80"
+              alt="Ceramic mugs arranged on a shelf"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1510906594845-bc082582c8cc?auto=format&fit=crop&w=900&q=80"
+              alt="Pair of ceramic cups with gradient glaze"
+            />
           </div>
           <div class="product-info">
-            <span class="pill">Studio exclusive</span>
+            <span class="pill">Studio ritual</span>
             <h3>Mist Horizon Cup Duo</h3>
-            <p>Soft gradient mugs with ergonomic handles and luminous sheen.</p>
+            <p>Soft gradient mugs shaped for morning sketchbook sessions.</p>
             <div class="product-meta">
-              <span class="price">$88</span>
-              <span class="availability">Set of two</span>
+              <span class="price">Focus: Ergonomic handles</span>
+              <span class="availability">Status: Daily use set</span>
             </div>
           </div>
         </article>
@@ -187,56 +322,86 @@
       <div class="section-header">
         <div>
           <p class="section-kicker">Stickers</p>
-          <h2>Illustrated stories that stick with you</h2>
+          <h2>Illustrated stories from the sketchbook</h2>
         </div>
-        <a class="section-link" href="#gallery">Shop sticker packs</a>
+        <a class="section-link" href="#gallery">View sticker experiments</a>
       </div>
       <div class="product-grid">
         <article class="product-card hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=900&q=80" alt="Hands sorting through illustrated stickers" class="active" />
-            <img src="https://images.unsplash.com/photo-1512436991641-6745cdb1723f?auto=format&fit=crop&w=900&q=80" alt="Sticker sheet with colorful illustrations" />
-            <img src="https://images.unsplash.com/photo-1529335764857-3f1164d1cb24?auto=format&fit=crop&w=900&q=80" alt="Sticker pack spread across a desk" />
+            <img
+              src="https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=900&q=80"
+              alt="Hands sorting through illustrated stickers"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1512436991641-6745cdb1723f?auto=format&fit=crop&w=900&q=80"
+              alt="Sticker sheet with colorful illustrations"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1529335764857-3f1164d1cb24?auto=format&fit=crop&w=900&q=80"
+              alt="Sticker pack spread across a desk"
+            />
           </div>
           <div class="product-info">
-            <span class="pill">New artist</span>
+            <span class="pill">Character study</span>
             <h3>Daydreamer Decals</h3>
-            <p>Whimsical characters exploring starry skies and cozy studios.</p>
+            <p>Whimsical characters navigating starry skies and cozy studios.</p>
             <div class="product-meta">
-              <span class="price">$18</span>
-              <span class="availability">Pack of 12</span>
+              <span class="price">Focus: Cozy astronaut narratives</span>
+              <span class="availability">Status: 2024 sticker swap</span>
             </div>
           </div>
         </article>
         <article class="product-card hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1513364776144-60967b0f800f?auto=format&fit=crop&w=900&q=80" alt="Sticker-filled journal with neon accents" class="active" />
-            <img src="https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=900&q=80" alt="Close-up of holographic stickers" />
-            <img src="https://images.unsplash.com/photo-1531482615713-2afd69097998?auto=format&fit=crop&w=900&q=80" alt="Sticker sheet featuring modern shapes" />
+            <img
+              src="https://images.unsplash.com/photo-1513364776144-60967b0f800f?auto=format&fit=crop&w=900&q=80"
+              alt="Sticker-filled journal with neon accents"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=900&q=80"
+              alt="Close-up of holographic stickers"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1531482615713-2afd69097998?auto=format&fit=crop&w=900&q=80"
+              alt="Sticker sheet featuring modern shapes"
+            />
           </div>
           <div class="product-info">
-            <span class="pill accent">Holographic</span>
+            <span class="pill accent">Holographic layering</span>
             <h3>Neon Pulse Sheets</h3>
-            <p>Layered neon gradients with iridescent overlays for journals and tech.</p>
+            <p>Experimenting with layered neon gradients and iridescent overlays.</p>
             <div class="product-meta">
-              <span class="price">$22</span>
-              <span class="availability">Limited run</span>
+              <span class="price">Focus: Electric color transitions</span>
+              <span class="availability">Status: Shared with maker friends</span>
             </div>
           </div>
         </article>
         <article class="product-card hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1502741338009-cac2772e18bc?auto=format&fit=crop&w=900&q=80" alt="Sticker pack featuring nature illustrations" class="active" />
-            <img src="https://images.unsplash.com/photo-1529333166433-7750a6dd5a70?auto=format&fit=crop&w=900&q=80" alt="Person peeling a sticker off a sheet" />
-            <img src="https://images.unsplash.com/photo-1521587760476-6c12a4b040da?auto=format&fit=crop&w=900&q=80" alt="Sticker sheets arranged on a table" />
+            <img
+              src="https://images.unsplash.com/photo-1502741338009-cac2772e18bc?auto=format&fit=crop&w=900&q=80"
+              alt="Sticker pack featuring nature illustrations"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1529333166433-7750a6dd5a70?auto=format&fit=crop&w=900&q=80"
+              alt="Person peeling a sticker off a sheet"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1521587760476-6c12a4b040da?auto=format&fit=crop&w=900&q=80"
+              alt="Sticker sheets arranged on a table"
+            />
           </div>
           <div class="product-info">
-            <span class="pill">Eco inks</span>
+            <span class="pill">Nature journal</span>
             <h3>Wander Wild Pack</h3>
             <p>Botanical illustrations printed on recycled matte stock.</p>
             <div class="product-meta">
-              <span class="price">$16</span>
-              <span class="availability">Set of 10</span>
+              <span class="price">Focus: Botanical line work</span>
+              <span class="availability">Status: Released in zine club</span>
             </div>
           </div>
         </article>
@@ -247,116 +412,176 @@
       <div class="section-header">
         <div>
           <p class="section-kicker">Woodwork</p>
-          <h2>Heritage woodworking reimagined</h2>
+          <h2>Handcrafted builds for the home studio</h2>
         </div>
-        <a class="section-link" href="#gallery">Discover woodwork</a>
+        <a class="section-link" href="#gallery">See woodwork progress</a>
       </div>
       <div class="product-grid">
         <article class="product-card hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1460518451285-97b6aa326961?auto=format&fit=crop&w=900&q=80" alt="Handcrafted wooden chair" class="active" />
-            <img src="https://images.unsplash.com/photo-1445991842772-097fea258e7b?auto=format&fit=crop&w=900&q=80" alt="Woodworker carving a wooden piece" />
-            <img src="https://images.unsplash.com/photo-1479064555552-3ef4979f8908?auto=format&fit=crop&w=900&q=80" alt="Close-up of wood grain on a crafted object" />
+            <img
+              src="https://images.unsplash.com/photo-1460518451285-97b6aa326961?auto=format&fit=crop&w=900&q=80"
+              alt="Handcrafted wooden chair"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1445991842772-097fea258e7b?auto=format&fit=crop&w=900&q=80"
+              alt="Woodworker carving a wooden piece"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1479064555552-3ef4979f8908?auto=format&fit=crop&w=900&q=80"
+              alt="Close-up of wood grain on a crafted object"
+            />
           </div>
           <div class="product-info">
-            <span class="pill accent">Edition of 20</span>
+            <span class="pill accent">Form study</span>
             <h3>Contour Lounge Chair</h3>
-            <p>Steam-bent walnut with woven leather seat and luminous finish.</p>
+            <p>Steam-bent walnut paired with a woven leather seat for restorative breaks.</p>
             <div class="product-meta">
-              <span class="price">$980</span>
-              <span class="availability">Pre-order</span>
+              <span class="price">Focus: Flowing frame geometry</span>
+              <span class="availability">Status: Finished prototype</span>
             </div>
           </div>
         </article>
         <article class="product-card hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1455778976758-b50394e8ef21?auto=format&fit=crop&w=900&q=80" alt="Woodworker crafting a jewelry box" class="active" />
-            <img src="https://images.unsplash.com/photo-1462396881884-de2c07cb95ed?auto=format&fit=crop&w=900&q=80" alt="Wooden boxes stacked together" />
-            <img src="https://images.unsplash.com/photo-1445510861639-5651173bc5d5?auto=format&fit=crop&w=900&q=80" alt="Wood grain close-up with carved detail" />
+            <img
+              src="https://images.unsplash.com/photo-1455778976758-b50394e8ef21?auto=format&fit=crop&w=900&q=80"
+              alt="Woodworker crafting a jewelry box"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1462396881884-de2c07cb95ed?auto=format&fit=crop&w=900&q=80"
+              alt="Wooden boxes stacked together"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1445510861639-5651173bc5d5?auto=format&fit=crop&w=900&q=80"
+              alt="Wood grain close-up with carved detail"
+            />
           </div>
           <div class="product-info">
-            <span class="pill">Modular</span>
+            <span class="pill">Joinery lab</span>
             <h3>Keepsake Vault Trio</h3>
             <p>Magnetic joinery boxes carved from reclaimed oak and maple.</p>
             <div class="product-meta">
-              <span class="price">$320</span>
-              <span class="availability">Set of three</span>
+              <span class="price">Focus: Hidden compartment mechanisms</span>
+              <span class="availability">Status: Iterating interiors</span>
             </div>
           </div>
         </article>
         <article class="product-card hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1447933601403-0c6688de566e?auto=format&fit=crop&w=900&q=80" alt="Wooden desk accessories" class="active" />
-            <img src="https://images.unsplash.com/photo-1525966222134-fcfa99b8ae77?auto=format&fit=crop&w=900&q=80" alt="Woodworker smoothing a board" />
-            <img src="https://images.unsplash.com/photo-1432139555190-58524dae6a55?auto=format&fit=crop&w=900&q=80" alt="Wooden geometric objects" />
+            <img
+              src="https://images.unsplash.com/photo-1447933601403-0c6688de566e?auto=format&fit=crop&w=900&q=80"
+              alt="Wooden desk accessories"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1525966222134-fcfa99b8ae77?auto=format&fit=crop&w=900&q=80"
+              alt="Woodworker smoothing a board"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1432139555190-58524dae6a55?auto=format&fit=crop&w=900&q=80"
+              alt="Wooden geometric objects"
+            />
           </div>
           <div class="product-info">
-            <span class="pill">Desk essentials</span>
+            <span class="pill">Workspace upgrade</span>
             <h3>Orbit Desk Set</h3>
-            <p>Modular organizers with brass inlays for modern workspaces.</p>
+            <p>Modular organizers with brass inlays to support daily making rituals.</p>
             <div class="product-meta">
-              <span class="price">$210</span>
-              <span class="availability">Ships in 1 week</span>
+              <span class="price">Focus: Modular layout planning</span>
+              <span class="availability">Status: Ships in-house soon</span>
             </div>
           </div>
         </article>
       </div>
     </section>
 
-    <section class="category" id="metalwork">
+    <section class="category" id="painting">
       <div class="section-header">
         <div>
-          <p class="section-kicker">Metalwork</p>
-          <h2>Sculpted alloys with luminous finishes</h2>
+          <p class="section-kicker">Painting</p>
+          <h2>Acrylic and watercolor journeys on canvas</h2>
         </div>
-        <a class="section-link" href="#gallery">View all metalwork</a>
+        <a class="section-link" href="#gallery">Browse painting explorations</a>
       </div>
       <div class="product-grid">
         <article class="product-card hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=900&q=80" alt="Metallic sculpture with organic shape" class="active" />
-            <img src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=900&q=80" alt="Metalworker welding a sculpture" />
-            <img src="https://images.unsplash.com/photo-1522778119026-d647f0596c20?auto=format&fit=crop&w=900&q=80" alt="Polished metal art piece" />
+            <img
+              src="https://images.unsplash.com/flagged/photo-1579546928687-0f9be64c77b4?auto=format&fit=crop&w=900&q=80"
+              alt="Abstract acrylic painting with swirling colors"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/flagged/photo-1579546928687-0f9be64c77b4?auto=format&fit=crop&w=900&q=80&sat=-100&blend=8c57ff&blend-mode=screen"
+              alt="Abstract acrylic painting with violet highlights"
+            />
+            <img
+              src="https://images.unsplash.com/flagged/photo-1579546928687-0f9be64c77b4?auto=format&fit=crop&w=900&q=80&sat=25"
+              alt="Detail of palette knife acrylic textures"
+            />
           </div>
           <div class="product-info">
-            <span class="pill accent">Studio spotlight</span>
-            <h3>Lumen Flow Sculpture</h3>
-            <p>Cold-cast brass with prismatic patina and soft luminance.</p>
+            <span class="pill accent">Palette knife play</span>
+            <h3>Chromatic Horizon Series</h3>
+            <p>Layering acrylic color fields inspired by sunrise runs and city lights.</p>
             <div class="product-meta">
-              <span class="price">$640</span>
-              <span class="availability">Edition of 15</span>
+              <span class="price">Focus: Saturated gradient blending</span>
+              <span class="availability">Status: Drying between layers</span>
             </div>
           </div>
         </article>
         <article class="product-card hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1577086664693-894d8405334c?auto=format&fit=crop&w=900&q=80" alt="Handcrafted metal jewelry pieces" class="active" />
-            <img src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=80" alt="Craftsperson polishing metal rings" />
-            <img src="https://images.unsplash.com/photo-1503602642458-232111445657?auto=format&fit=crop&w=900&q=80" alt="Metallic art pieces displayed on a table" />
+            <img
+              src="https://images.unsplash.com/photo-1462212210333-335063b6762f?auto=format&fit=crop&w=900&q=80"
+              alt="Watercolor palette with brushes"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1462212210333-335063b6762f?auto=format&fit=crop&w=900&q=80&sat=-15"
+              alt="Watercolor palette with muted tones"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1462212210333-335063b6762f?auto=format&fit=crop&w=900&q=80&blend=3cc8ab&blend-mode=screen"
+              alt="Watercolor palette with teal overlay"
+            />
           </div>
           <div class="product-info">
-            <span class="pill">Hand forged</span>
-            <h3>Orbit Halo Jewelry Set</h3>
-            <p>Sculptural cuffs and rings forged in recycled sterling silver.</p>
+            <span class="pill">Watercolor wash</span>
+            <h3>Riverbed Sketch Studies</h3>
+            <p>Exploring transparent layers that capture misty trails and mossy banks.</p>
             <div class="product-meta">
-              <span class="price">$290</span>
-              <span class="availability">Made to size</span>
+              <span class="price">Focus: Loose landscape gestures</span>
+              <span class="availability">Status: Sketchbook residency</span>
             </div>
           </div>
         </article>
         <article class="product-card hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1452587925148-ce544e77e70d?auto=format&fit=crop&w=900&q=80" alt="Metal lamp with geometric design" class="active" />
-            <img src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=900&q=80" alt="Metalworker shaping a lamp" />
-            <img src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=900&q=80" alt="Modern metal lamp glowing" />
+            <img
+              src="https://images.unsplash.com/photo-1501004318641-b39e6451bec6?auto=format&fit=crop&w=900&q=80"
+              alt="Artist painting on canvas with a brush"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1501004318641-b39e6451bec6?auto=format&fit=crop&w=900&q=80&sat=-50"
+              alt="Artist painting with soft monochrome tones"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1501004318641-b39e6451bec6?auto=format&fit=crop&w=900&q=80&blend=ffe7f3&blend-mode=multiply"
+              alt="Close-up of paint strokes on canvas"
+            />
           </div>
           <div class="product-info">
-            <span class="pill">Ambient</span>
-            <h3>Halo Arc Lighting</h3>
-            <p>Dim-to-warm LED lamp framed by brushed titanium arcs.</p>
+            <span class="pill">Hybrid practice</span>
+            <h3>Studio Portrait Sessions</h3>
+            <p>Combining acrylic underpaintings with watercolor glazes for airy figures.</p>
             <div class="product-meta">
-              <span class="price">$420</span>
-              <span class="availability">Ships worldwide</span>
+              <span class="price">Focus: Mixed-media layering</span>
+              <span class="availability">Status: Critique ready</span>
             </div>
           </div>
         </article>
@@ -366,57 +591,87 @@
     <section class="category" id="digital">
       <div class="section-header">
         <div>
-          <p class="section-kicker">Digital Assets</p>
-          <h2>Templates and textures for creators</h2>
+          <p class="section-kicker">Digital Projects</p>
+          <h2>Templates and textures for creative experiments</h2>
         </div>
-        <a class="section-link" href="#gallery">Browse digital vault</a>
+        <a class="section-link" href="#gallery">Explore digital projects</a>
       </div>
       <div class="product-grid">
         <article class="product-card hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=900&q=80" alt="Digital mockups displayed on laptop" class="active" />
-            <img src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=900&q=80" alt="Design templates on a desktop setup" />
-            <img src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=900&q=80&sat=-100" alt="Graphic designer working with templates" />
+            <img
+              src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=900&q=80"
+              alt="Digital mockups displayed on laptop"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=900&q=80"
+              alt="Design templates on a desktop setup"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=900&q=80&sat=-100"
+              alt="Graphic designer working with templates"
+            />
           </div>
           <div class="product-info">
             <span class="pill accent">Pro kit</span>
             <h3>Brand Launch Blueprint</h3>
             <p>40-page Figma template suite for cohesive brand storytelling.</p>
             <div class="product-meta">
-              <span class="price">$68</span>
-              <span class="availability">Instant download</span>
+              <span class="price">Focus: Narrative-driven identity</span>
+              <span class="availability">Status: Available for collaborators</span>
             </div>
           </div>
         </article>
         <article class="product-card hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=900&q=80&sat=-100&blend=8c57ff&blend-mode=screen" alt="Colorful digital textures on tablet" class="active" />
-            <img src="https://images.unsplash.com/photo-1526481280695-3c4693f99254?auto=format&fit=crop&w=900&q=80" alt="Designer working on digital tablet" />
-            <img src="https://images.unsplash.com/photo-1587614382346-4ec892f9aca3?auto=format&fit=crop&w=900&q=80" alt="Abstract digital backgrounds" />
+            <img
+              src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=900&q=80&sat=-100&blend=8c57ff&blend-mode=screen"
+              alt="Colorful digital textures on tablet"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1526481280695-3c4693f99254?auto=format&fit=crop&w=900&q=80"
+              alt="Designer working on digital tablet"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1587614382346-4ec892f9aca3?auto=format&fit=crop&w=900&q=80"
+              alt="Abstract digital backgrounds"
+            />
           </div>
           <div class="product-info">
             <span class="pill">Texture pack</span>
             <h3>Chromatic Noise Overlays</h3>
             <p>50 layered PSD textures for moody lighting and grain effects.</p>
             <div class="product-meta">
-              <span class="price">$32</span>
-              <span class="availability">Commercial use</span>
+              <span class="price">Focus: Atmospheric lighting</span>
+              <span class="availability">Status: Updated quarterly</span>
             </div>
           </div>
         </article>
         <article class="product-card hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=900&q=80&sat=-100&blend=67eaca&blend-mode=screen" alt="Digital moodboards displayed on monitors" class="active" />
-            <img src="https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=900&q=80" alt="Team collaborating on digital design" />
-            <img src="https://images.unsplash.com/photo-1487014679447-9f8336841d58?auto=format&fit=crop&w=900&q=80" alt="Digital design elements spread on table" />
+            <img
+              src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=900&q=80&sat=-100&blend=67eaca&blend-mode=screen"
+              alt="Digital moodboards displayed on monitors"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=900&q=80"
+              alt="Team collaborating on digital design"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1487014679447-9f8336841d58?auto=format&fit=crop&w=900&q=80"
+              alt="Digital design elements spread on table"
+            />
           </div>
           <div class="product-info">
             <span class="pill">Workflow</span>
             <h3>Creative Sprint Planner</h3>
             <p>Notion and PDF templates to organize design sprints and retros.</p>
             <div class="product-meta">
-              <span class="price">$24</span>
-              <span class="availability">Bundle</span>
+              <span class="price">Focus: Habit building for makers</span>
+              <span class="availability">Status: Bundle in progress</span>
             </div>
           </div>
         </article>
@@ -427,42 +682,82 @@
       <div class="section-header">
         <div>
           <p class="section-kicker">Gallery</p>
-          <h2>Collector moments</h2>
+          <h2>Studio moments</h2>
         </div>
         <a class="section-link" href="#top">Back to top</a>
       </div>
       <div class="gallery-grid">
         <figure class="gallery-item hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=900&q=80" alt="Collector shelf with ceramics" class="active" />
-            <img src="https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=900&q=80&sat=-100&blend=8c57ff&blend-mode=screen" alt="Ceramics with colorful highlights" />
-            <img src="https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=900&q=80" alt="Metal and ceramic objects arranged together" />
+            <img
+              src="https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=900&q=80"
+              alt="Studio shelf with ceramics"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=900&q=80&sat=-100&blend=8c57ff&blend-mode=screen"
+              alt="Ceramics with colorful highlights"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=900&q=80"
+              alt="Metal and ceramic objects arranged together"
+            />
           </div>
-          <figcaption>Studio shelf styled by @ClayConstellations</figcaption>
+          <figcaption>Studio shelf styled for the Cosmic Clay Series.</figcaption>
         </figure>
         <figure class="gallery-item hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1517686469429-8bdb88b9f907?auto=format&fit=crop&w=900&q=80" alt="Artist arranging stickers on wall" class="active" />
-            <img src="https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=900&q=80" alt="Sticker wall collage" />
-            <img src="https://images.unsplash.com/photo-1529333166433-7750a6dd5a70?auto=format&fit=crop&w=900&q=80" alt="Sticker board details" />
+            <img
+              src="https://images.unsplash.com/photo-1517686469429-8bdb88b9f907?auto=format&fit=crop&w=900&q=80"
+              alt="Artist arranging stickers on wall"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=900&q=80"
+              alt="Sticker wall collage"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1529333166433-7750a6dd5a70?auto=format&fit=crop&w=900&q=80"
+              alt="Sticker board details"
+            />
           </div>
-          <figcaption>Pop-up sticker lab during our spring meetup</figcaption>
+          <figcaption>Pop-up sticker lab during the spring sketchbook meetup.</figcaption>
         </figure>
         <figure class="gallery-item hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1449247709967-d4461a6a6103?auto=format&fit=crop&w=900&q=80" alt="Metal and wood art installation" class="active" />
-            <img src="https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=900&q=80&sat=-100&blend=67eaca&blend-mode=screen" alt="Metal art with teal accent" />
-            <img src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=900&q=80" alt="Close-up of ceramic vase with metal frame" />
+            <img
+              src="https://images.unsplash.com/photo-1449247709967-d4461a6a6103?auto=format&fit=crop&w=900&q=80"
+              alt="Metal and wood art installation"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=900&q=80&sat=-100&blend=67eaca&blend-mode=screen"
+              alt="Metal art with teal accent"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=900&q=80"
+              alt="Close-up of ceramic vase with metal frame"
+            />
           </div>
-          <figcaption>Mixed media installation in the collector lounge</figcaption>
+          <figcaption>Mixed-media installation pairing woodwork, ceramics, and paint.</figcaption>
         </figure>
         <figure class="gallery-item hover-carousel">
           <div class="media-stack">
-            <img src="https://images.unsplash.com/photo-1532960400002-577fd10ff0d9?auto=format&fit=crop&w=900&q=80" alt="Digital work displayed at community event" class="active" />
-            <img src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=900&q=80&sat=-100&blend=ffb74d&blend-mode=multiply" alt="Digital art monitors" />
-            <img src="https://images.unsplash.com/photo-1487014679447-9f8336841d58?auto=format&fit=crop&w=900&q=80" alt="Workshop participants using tablets" />
+            <img
+              src="https://images.unsplash.com/photo-1532960400002-577fd10ff0d9?auto=format&fit=crop&w=900&q=80"
+              alt="Digital work displayed at community event"
+              class="active"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=900&q=80&sat=-100&blend=ffb74d&blend-mode=multiply"
+              alt="Digital art monitors"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1487014679447-9f8336841d58?auto=format&fit=crop&w=900&q=80"
+              alt="Workshop participants using tablets"
+            />
           </div>
-          <figcaption>Digital creators showcase featuring modular templates</figcaption>
+          <figcaption>Digital creators showcase featuring modular templates.</figcaption>
         </figure>
       </div>
     </section>
@@ -475,7 +770,9 @@
           <span class="logo-mark">HK</span>
           <span class="logo-type">Hobby Kollector</span>
         </div>
-        <p>Curated goods and digital tools for collectors and makers. Join the drop list to hear about the next release first.</p>
+        <p>
+          Notes from an ever-curious maker. Join the studio list to hear about new hobbies, workshops, and process breakdowns first.
+        </p>
       </div>
       <div>
         <h3>Visit</h3>


### PR DESCRIPTION
## Summary
- reframe the site's title, meta description, hero, and footer copy to describe Hobby Kollector as an artist collecting creative hobbies
- refresh ceramics, stickers, woodwork, and digital project blurbs to focus on process details instead of pricing language
- replace the metalwork navigation item and section with a painting focus including new imagery and descriptions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc2f5f31e4832a9d5370b4530f6733