### PR TITLE
Fix painting images and update cart icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,14 +161,35 @@
       <button class="icon-btn journal" type="button" aria-label="Open the studio journal">
         <span class="icon-wrapper">
           <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
-            ><path
-              d="M6 4h9a4 4 0 014 4v12H8a2 2 0 00-2 2V4z"
+            ><circle
+              cx="9"
+              cy="21"
+              r="1.5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            /><circle
+              cx="20"
+              cy="21"
+              r="1.5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            /><path
+              d="M2 4h3l2.2 11.4a2 2 0 002 1.6h9.5a2 2 0 001.95-1.6L22 7H6"
               fill="none"
               stroke="currentColor"
               stroke-width="2"
               stroke-linecap="round"
               stroke-linejoin="round"
-            /><path d="M14 4v16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" /></svg
+            /><path
+              d="M8 13h11"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            /></svg
           >
         </span>
       </button>
@@ -510,16 +531,16 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/flagged/photo-1579546928687-0f9be64c77b4?auto=format&fit=crop&w=900&q=80"
+              src="https://images.unsplash.com/photo-1504198453319-5ce911bafcde?auto=format&fit=crop&w=900&q=80"
               alt="Abstract acrylic painting with swirling colors"
               class="active"
             />
             <img
-              src="https://images.unsplash.com/flagged/photo-1579546928687-0f9be64c77b4?auto=format&fit=crop&w=900&q=80&sat=-100&blend=8c57ff&blend-mode=screen"
+              src="https://images.unsplash.com/photo-1504198453319-5ce911bafcde?auto=format&fit=crop&w=900&q=80&sat=-35"
               alt="Abstract acrylic painting with violet highlights"
             />
             <img
-              src="https://images.unsplash.com/flagged/photo-1579546928687-0f9be64c77b4?auto=format&fit=crop&w=900&q=80&sat=25"
+              src="https://images.unsplash.com/photo-1504198453319-5ce911bafcde?auto=format&fit=crop&w=900&q=80&blend=8c57ff&blend-mode=screen"
               alt="Detail of palette knife acrylic textures"
             />
           </div>
@@ -536,16 +557,16 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/photo-1462212210333-335063b6762f?auto=format&fit=crop&w=900&q=80"
+              src="https://images.unsplash.com/photo-1526498460520-4c246339dccb?auto=format&fit=crop&w=900&q=80"
               alt="Watercolor palette with brushes"
               class="active"
             />
             <img
-              src="https://images.unsplash.com/photo-1462212210333-335063b6762f?auto=format&fit=crop&w=900&q=80&sat=-15"
+              src="https://images.unsplash.com/photo-1526498460520-4c246339dccb?auto=format&fit=crop&w=900&q=80&sat=-20"
               alt="Watercolor palette with muted tones"
             />
             <img
-              src="https://images.unsplash.com/photo-1462212210333-335063b6762f?auto=format&fit=crop&w=900&q=80&blend=3cc8ab&blend-mode=screen"
+              src="https://images.unsplash.com/photo-1526498460520-4c246339dccb?auto=format&fit=crop&w=900&q=80&blend=3cc8ab&blend-mode=screen"
               alt="Watercolor palette with teal overlay"
             />
           </div>


### PR DESCRIPTION
## Summary
- replace the missing painting carousel images with accessible Unsplash sources so all slides load
- swap the header journal glyph for a shopping cart icon while keeping the existing button styling

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc3d1bdc30832a8ff8d47414990648