### PR TITLE
Adjust gallery imagery to match section themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,17 +261,17 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=900&q=80"
-              alt="Celestial blue ceramic vase"
+              src="https://source.unsplash.com/900x900/?ceramic,mug,crystalline,glaze&sig=11"
+              alt="Random Unsplash ceramic mug with crystalline glaze finish"
               class="active"
             />
             <img
-              src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=80"
-              alt="Glazed ceramic vases displayed together"
+              src="https://source.unsplash.com/900x900/?pottery,crystal,glaze&sig=12"
+              alt="Random Unsplash close-up of crystal glaze pottery"
             />
             <img
-              src="https://images.unsplash.com/photo-1462396881884-de2c07cb95ed?auto=format&fit=crop&w=900&q=80"
-              alt="Close-up of ceramic glaze details"
+              src="https://source.unsplash.com/900x900/?ceramic,cup,glaze&sig=13"
+              alt="Random Unsplash ceramic cup showcasing shimmering glaze"
             />
           </div>
           <div class="product-info">
@@ -287,17 +287,17 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=900&q=80"
-              alt="Stack of ceramic plates in earth tones"
+              src="https://source.unsplash.com/900x900/?stoneware,plates,handmade&sig=14"
+              alt="Random Unsplash stoneware dinner plates with handmade details"
               class="active"
             />
             <img
-              src="https://images.unsplash.com/photo-1451471016731-e963a8588be8?auto=format&fit=crop&w=900&q=80"
-              alt="Artist painting ceramic plates"
+              src="https://source.unsplash.com/900x900/?ceramic,plate,brushstroke&sig=15"
+              alt="Random Unsplash ceramic plate featuring painterly strokes"
             />
             <img
-              src="https://images.unsplash.com/photo-1522780550605-98e7b380d0bc?auto=format&fit=crop&w=900&q=80"
-              alt="Ceramic plates with brush stroke patterns"
+              src="https://source.unsplash.com/900x900/?pottery,tableware,studio&sig=16"
+              alt="Random Unsplash studio tableware arrangement"
             />
           </div>
           <div class="product-info">
@@ -313,17 +313,17 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/photo-1551218808-94e220e084d2?auto=format&fit=crop&w=900&q=80"
-              alt="Minimal ceramic mugs on a table"
+              src="https://source.unsplash.com/900x900/?ceramic,mugs,handmade&sig=17"
+              alt="Random Unsplash handmade ceramic mugs with glossy glaze"
               class="active"
             />
             <img
-              src="https://images.unsplash.com/photo-1481349518771-20055b2a7b24?auto=format&fit=crop&w=900&q=80"
-              alt="Ceramic mugs arranged on a shelf"
+              src="https://source.unsplash.com/900x900/?ceramic,teacup,glaze&sig=18"
+              alt="Random Unsplash ceramic teacups with layered glaze"
             />
             <img
-              src="https://images.unsplash.com/photo-1510906594845-bc082582c8cc?auto=format&fit=crop&w=900&q=80"
-              alt="Pair of ceramic cups with gradient glaze"
+              src="https://source.unsplash.com/900x900/?pottery,cup,artisan&sig=19"
+              alt="Random Unsplash artisan ceramic cups on display"
             />
           </div>
           <div class="product-info">
@@ -351,17 +351,17 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=900&q=80"
-              alt="Hands sorting through illustrated stickers"
+              src="https://source.unsplash.com/900x900/?vinyl,stickers,cute&sig=31"
+              alt="Random Unsplash assortment of cute vinyl stickers"
               class="active"
             />
             <img
-              src="https://images.unsplash.com/photo-1512436991641-6745cdb1723f?auto=format&fit=crop&w=900&q=80"
-              alt="Sticker sheet with colorful illustrations"
+              src="https://source.unsplash.com/900x900/?sticker,collection,colorful&sig=32"
+              alt="Random Unsplash colorful sticker collection on a desk"
             />
             <img
-              src="https://images.unsplash.com/photo-1529335764857-3f1164d1cb24?auto=format&fit=crop&w=900&q=80"
-              alt="Sticker pack spread across a desk"
+              src="https://source.unsplash.com/900x900/?sticker,sheet,illustration&sig=33"
+              alt="Random Unsplash illustrated sticker sheet spread out"
             />
           </div>
           <div class="product-info">
@@ -377,17 +377,17 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/photo-1513364776144-60967b0f800f?auto=format&fit=crop&w=900&q=80"
-              alt="Sticker-filled journal with neon accents"
+              src="https://source.unsplash.com/900x900/?holographic,sticker,set&sig=34"
+              alt="Random Unsplash holographic stickers arranged in a journal"
               class="active"
             />
             <img
-              src="https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=900&q=80"
-              alt="Close-up of holographic stickers"
+              src="https://source.unsplash.com/900x900/?neon,sticker,pack&sig=35"
+              alt="Random Unsplash neon-inspired sticker pack"
             />
             <img
-              src="https://images.unsplash.com/photo-1531482615713-2afd69097998?auto=format&fit=crop&w=900&q=80"
-              alt="Sticker sheet featuring modern shapes"
+              src="https://source.unsplash.com/900x900/?iridescent,stickers,design&sig=36"
+              alt="Random Unsplash iridescent sticker designs"
             />
           </div>
           <div class="product-info">
@@ -403,17 +403,17 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/photo-1502741338009-cac2772e18bc?auto=format&fit=crop&w=900&q=80"
-              alt="Sticker pack featuring nature illustrations"
+              src="https://source.unsplash.com/900x900/?botanical,stickers,vinyl&sig=37"
+              alt="Random Unsplash botanical vinyl stickers"
               class="active"
             />
             <img
-              src="https://images.unsplash.com/photo-1529333166433-7750a6dd5a70?auto=format&fit=crop&w=900&q=80"
-              alt="Person peeling a sticker off a sheet"
+              src="https://source.unsplash.com/900x900/?nature,sticker,set&sig=38"
+              alt="Random Unsplash nature-themed sticker sheet"
             />
             <img
-              src="https://images.unsplash.com/photo-1521587760476-6c12a4b040da?auto=format&fit=crop&w=900&q=80"
-              alt="Sticker sheets arranged on a table"
+              src="https://source.unsplash.com/900x900/?outdoor,sticker,collection&sig=39"
+              alt="Random Unsplash sticker collection inspired by the outdoors"
             />
           </div>
           <div class="product-info">
@@ -531,17 +531,17 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/photo-1504198453319-5ce911bafcde?auto=format&fit=crop&w=900&q=80"
-              alt="Abstract acrylic painting with swirling colors"
+              src="https://source.unsplash.com/900x900/?canvas,painting,studio&sig=41"
+              alt="Random Unsplash artist working on a canvas painting in studio"
               class="active"
             />
             <img
-              src="https://images.unsplash.com/photo-1504198453319-5ce911bafcde?auto=format&fit=crop&w=900&q=80&sat=-35"
-              alt="Abstract acrylic painting with violet highlights"
+              src="https://source.unsplash.com/900x900/?abstract,painting,canvas&sig=42"
+              alt="Random Unsplash abstract painting on stretched canvas"
             />
             <img
-              src="https://images.unsplash.com/photo-1504198453319-5ce911bafcde?auto=format&fit=crop&w=900&q=80&blend=8c57ff&blend-mode=screen"
-              alt="Detail of palette knife acrylic textures"
+              src="https://source.unsplash.com/900x900/?palette,knife,painting&sig=43"
+              alt="Random Unsplash palette knife textures on a canvas painting"
             />
           </div>
           <div class="product-info">
@@ -557,17 +557,17 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/photo-1526498460520-4c246339dccb?auto=format&fit=crop&w=900&q=80"
-              alt="Watercolor palette with brushes"
+              src="https://source.unsplash.com/900x900/?watercolor,canvas,art&sig=44"
+              alt="Random Unsplash watercolor washes across canvas"
               class="active"
             />
             <img
-              src="https://images.unsplash.com/photo-1526498460520-4c246339dccb?auto=format&fit=crop&w=900&q=80&sat=-20"
-              alt="Watercolor palette with muted tones"
+              src="https://source.unsplash.com/900x900/?watercolor,palette,artist&sig=45"
+              alt="Random Unsplash watercolor artist tools beside a painting"
             />
             <img
-              src="https://images.unsplash.com/photo-1526498460520-4c246339dccb?auto=format&fit=crop&w=900&q=80&blend=3cc8ab&blend-mode=screen"
-              alt="Watercolor palette with teal overlay"
+              src="https://source.unsplash.com/900x900/?watercolor,landscape,art&sig=46"
+              alt="Random Unsplash watercolor landscape on paper"
             />
           </div>
           <div class="product-info">
@@ -583,17 +583,17 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/photo-1501004318641-b39e6451bec6?auto=format&fit=crop&w=900&q=80"
-              alt="Artist painting on canvas with a brush"
+              src="https://source.unsplash.com/900x900/?portrait,painting,canvas&sig=47"
+              alt="Random Unsplash portrait being painted on canvas"
               class="active"
             />
             <img
-              src="https://images.unsplash.com/photo-1501004318641-b39e6451bec6?auto=format&fit=crop&w=900&q=80&sat=-50"
-              alt="Artist painting with soft monochrome tones"
+              src="https://source.unsplash.com/900x900/?figure,painting,studio&sig=48"
+              alt="Random Unsplash figure study painted on canvas"
             />
             <img
-              src="https://images.unsplash.com/photo-1501004318641-b39e6451bec6?auto=format&fit=crop&w=900&q=80&blend=ffe7f3&blend-mode=multiply"
-              alt="Close-up of paint strokes on canvas"
+              src="https://source.unsplash.com/900x900/?mixed-media,painting,canvas&sig=49"
+              alt="Random Unsplash mixed-media brushwork on canvas"
             />
           </div>
           <div class="product-info">
@@ -621,17 +621,17 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=900&q=80"
-              alt="Digital mockups displayed on laptop"
+              src="https://source.unsplash.com/900x900/?pencil,sketch,design&sig=51"
+              alt="Random Unsplash pencil sketch layout for digital design"
               class="active"
             />
             <img
-              src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=900&q=80"
-              alt="Design templates on a desktop setup"
+              src="https://source.unsplash.com/900x900/?wireframe,sketchbook,design&sig=52"
+              alt="Random Unsplash wireframe sketches in a sketchbook"
             />
             <img
-              src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=900&q=80&sat=-100"
-              alt="Graphic designer working with templates"
+              src="https://source.unsplash.com/900x900/?ux,sketch,planning&sig=53"
+              alt="Random Unsplash UX planning sketches drawn in pencil"
             />
           </div>
           <div class="product-info">
@@ -647,17 +647,17 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=900&q=80&sat=-100&blend=8c57ff&blend-mode=screen"
-              alt="Colorful digital textures on tablet"
+              src="https://source.unsplash.com/900x900/?stencil,sketch,pencil&sig=54"
+              alt="Random Unsplash stencil concepts drawn with pencil"
               class="active"
             />
             <img
-              src="https://images.unsplash.com/photo-1526481280695-3c4693f99254?auto=format&fit=crop&w=900&q=80"
-              alt="Designer working on digital tablet"
+              src="https://source.unsplash.com/900x900/?concept,art,sketch&sig=55"
+              alt="Random Unsplash concept art pencil sketches"
             />
             <img
-              src="https://images.unsplash.com/photo-1587614382346-4ec892f9aca3?auto=format&fit=crop&w=900&q=80"
-              alt="Abstract digital backgrounds"
+              src="https://source.unsplash.com/900x900/?pattern,sketchbook,pencil&sig=56"
+              alt="Random Unsplash pattern exploration sketched in pencil"
             />
           </div>
           <div class="product-info">
@@ -673,17 +673,17 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=900&q=80&sat=-100&blend=67eaca&blend-mode=screen"
-              alt="Digital moodboards displayed on monitors"
+              src="https://source.unsplash.com/900x900/?illustration,sketch,workspace&sig=57"
+              alt="Random Unsplash illustration sketches spread across a workspace"
               class="active"
             />
             <img
-              src="https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=900&q=80"
-              alt="Team collaborating on digital design"
+              src="https://source.unsplash.com/900x900/?storyboard,sketch,pencil&sig=58"
+              alt="Random Unsplash storyboard panels drawn with pencil"
             />
             <img
-              src="https://images.unsplash.com/photo-1487014679447-9f8336841d58?auto=format&fit=crop&w=900&q=80"
-              alt="Digital design elements spread on table"
+              src="https://source.unsplash.com/900x900/?drawing,templates,sketch&sig=59"
+              alt="Random Unsplash pencil templates for digital projects"
             />
           </div>
           <div class="product-info">


### PR DESCRIPTION
## Summary
- refresh ceramics product card imagery with query-targeted Unsplash sources that spotlight glazed mugs and tableware
- replace sticker and painting section thumbnails with Unsplash queries tuned for vinyl sticker collections and canvas artwork
- pivot digital project visuals to Unsplash pencil sketch queries for stencil-style references

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc42f2ae40832a9781cd344c729dfd