### PR TITLE
Adjust hero logo framing and add local artwork

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,17 +257,9 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://source.unsplash.com/900x900/?ceramic,mug,crystalline,glaze&sig=11"
-              alt="Random Unsplash ceramic mug with crystalline glaze finish"
+              src="img/Hand-thrown porcelain exploring layered nebula washes and gilded rims.jpg"
+              alt="Hand-thrown porcelain exploring layered nebula washes and gilded rims"
               class="active"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?pottery,crystal,glaze&sig=12"
-              alt="Random Unsplash close-up of crystal glaze pottery"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?ceramic,cup,glaze&sig=13"
-              alt="Random Unsplash ceramic cup showcasing shimmering glaze"
             />
           </div>
           <div class="product-info">
@@ -283,17 +275,9 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://source.unsplash.com/900x900/?stoneware,plates,handmade&sig=14"
-              alt="Random Unsplash stoneware dinner plates with handmade details"
+              src="img/Documenting warm stoneware plates brushed with matte gradients.jpg"
+              alt="Documenting warm stoneware plates brushed with matte gradients"
               class="active"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?ceramic,plate,brushstroke&sig=15"
-              alt="Random Unsplash ceramic plate featuring painterly strokes"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?pottery,tableware,studio&sig=16"
-              alt="Random Unsplash studio tableware arrangement"
             />
           </div>
           <div class="product-info">
@@ -309,17 +293,9 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://source.unsplash.com/900x900/?ceramic,mugs,handmade&sig=17"
-              alt="Random Unsplash handmade ceramic mugs with glossy glaze"
+              src="img/Soft gradient mugs shaped for morning sketchbook sessions.jpg"
+              alt="Soft gradient mugs shaped for morning sketchbook sessions"
               class="active"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?ceramic,teacup,glaze&sig=18"
-              alt="Random Unsplash ceramic teacups with layered glaze"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?pottery,cup,artisan&sig=19"
-              alt="Random Unsplash artisan ceramic cups on display"
             />
           </div>
           <div class="product-info">
@@ -347,17 +323,9 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://source.unsplash.com/900x900/?vinyl,stickers,cute&sig=31"
-              alt="Random Unsplash assortment of cute vinyl stickers"
+              src="img/Whimsical characters navigating starry skies and cozy studios.jpg"
+              alt="Whimsical characters navigating starry skies and cozy studios"
               class="active"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?sticker,collection,colorful&sig=32"
-              alt="Random Unsplash colorful sticker collection on a desk"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?sticker,sheet,illustration&sig=33"
-              alt="Random Unsplash illustrated sticker sheet spread out"
             />
           </div>
           <div class="product-info">
@@ -373,17 +341,9 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://source.unsplash.com/900x900/?holographic,sticker,set&sig=34"
-              alt="Random Unsplash holographic stickers arranged in a journal"
+              src="img/Experimenting with layered neon gradients and iridescent overlays.jpg"
+              alt="Experimenting with layered neon gradients and iridescent overlays"
               class="active"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?neon,sticker,pack&sig=35"
-              alt="Random Unsplash neon-inspired sticker pack"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?iridescent,stickers,design&sig=36"
-              alt="Random Unsplash iridescent sticker designs"
             />
           </div>
           <div class="product-info">
@@ -399,17 +359,9 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://source.unsplash.com/900x900/?botanical,stickers,vinyl&sig=37"
-              alt="Random Unsplash botanical vinyl stickers"
+              src="img/Botanical illustrations printed on recycled matte stock.jpg"
+              alt="Botanical illustrations printed on recycled matte stock"
               class="active"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?nature,sticker,set&sig=38"
-              alt="Random Unsplash nature-themed sticker sheet"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?outdoor,sticker,collection&sig=39"
-              alt="Random Unsplash sticker collection inspired by the outdoors"
             />
           </div>
           <div class="product-info">
@@ -437,17 +389,9 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/photo-1460518451285-97b6aa326961?auto=format&fit=crop&w=900&q=80"
-              alt="Handcrafted wooden chair"
+              src="img/Steam-bent walnut paired with a woven leather seat for restorative breaks.jpg"
+              alt="Steam-bent walnut paired with a woven leather seat for restorative breaks"
               class="active"
-            />
-            <img
-              src="https://images.unsplash.com/photo-1445991842772-097fea258e7b?auto=format&fit=crop&w=900&q=80"
-              alt="Woodworker carving a wooden piece"
-            />
-            <img
-              src="https://images.unsplash.com/photo-1479064555552-3ef4979f8908?auto=format&fit=crop&w=900&q=80"
-              alt="Close-up of wood grain on a crafted object"
             />
           </div>
           <div class="product-info">
@@ -463,17 +407,9 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/photo-1455778976758-b50394e8ef21?auto=format&fit=crop&w=900&q=80"
-              alt="Woodworker crafting a jewelry box"
+              src="img/Magnetic joinery boxes carved from reclaimed oak and maple.jpeg"
+              alt="Magnetic joinery boxes carved from reclaimed oak and maple"
               class="active"
-            />
-            <img
-              src="https://images.unsplash.com/photo-1462396881884-de2c07cb95ed?auto=format&fit=crop&w=900&q=80"
-              alt="Wooden boxes stacked together"
-            />
-            <img
-              src="https://images.unsplash.com/photo-1445510861639-5651173bc5d5?auto=format&fit=crop&w=900&q=80"
-              alt="Wood grain close-up with carved detail"
             />
           </div>
           <div class="product-info">
@@ -489,17 +425,9 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://images.unsplash.com/photo-1447933601403-0c6688de566e?auto=format&fit=crop&w=900&q=80"
-              alt="Wooden desk accessories"
+              src="img/Modular organizers with brass inlays to support daily making rituals.jpg"
+              alt="Modular organizers with brass inlays to support daily making rituals"
               class="active"
-            />
-            <img
-              src="https://images.unsplash.com/photo-1525966222134-fcfa99b8ae77?auto=format&fit=crop&w=900&q=80"
-              alt="Woodworker smoothing a board"
-            />
-            <img
-              src="https://images.unsplash.com/photo-1432139555190-58524dae6a55?auto=format&fit=crop&w=900&q=80"
-              alt="Wooden geometric objects"
             />
           </div>
           <div class="product-info">
@@ -527,17 +455,9 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://source.unsplash.com/900x900/?canvas,painting,studio&sig=41"
-              alt="Random Unsplash artist working on a canvas painting in studio"
+              src="img/Layering acrylic color fields inspired by sunrise runs and city lights.webp"
+              alt="Layering acrylic color fields inspired by sunrise runs and city lights"
               class="active"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?abstract,painting,canvas&sig=42"
-              alt="Random Unsplash abstract painting on stretched canvas"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?palette,knife,painting&sig=43"
-              alt="Random Unsplash palette knife textures on a canvas painting"
             />
           </div>
           <div class="product-info">
@@ -553,17 +473,9 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://source.unsplash.com/900x900/?watercolor,canvas,art&sig=44"
-              alt="Random Unsplash watercolor washes across canvas"
+              src="img/Exploring transparent layers that capture misty trails and mossy banks.jpg"
+              alt="Exploring transparent layers that capture misty trails and mossy banks"
               class="active"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?watercolor,palette,artist&sig=45"
-              alt="Random Unsplash watercolor artist tools beside a painting"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?watercolor,landscape,art&sig=46"
-              alt="Random Unsplash watercolor landscape on paper"
             />
           </div>
           <div class="product-info">
@@ -579,17 +491,9 @@
         <article class="product-card hover-carousel">
           <div class="media-stack">
             <img
-              src="https://source.unsplash.com/900x900/?portrait,painting,canvas&sig=47"
-              alt="Random Unsplash portrait being painted on canvas"
+              src="img/Combining acrylic underpaintings with watercolor glazes for airy figures.jpg"
+              alt="Combining acrylic underpaintings with watercolor glazes for airy figures"
               class="active"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?figure,painting,studio&sig=48"
-              alt="Random Unsplash figure study painted on canvas"
-            />
-            <img
-              src="https://source.unsplash.com/900x900/?mixed-media,painting,canvas&sig=49"
-              alt="Random Unsplash mixed-media brushwork on canvas"
             />
           </div>
           <div class="product-info">

--- a/styles.css
+++ b/styles.css
@@ -331,7 +331,12 @@ a:hover,
 
 .hero-card .media-stack {
   aspect-ratio: 3 / 4;
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0.55));
+  background: transparent;
+}
+
+.hero-card .media-stack img {
+  object-fit: contain;
+  background-color: transparent;
 }
 
 .hero-note {


### PR DESCRIPTION
## Summary
- remove the hero media card background so the transparent logo sits directly on the page gradient
- replace placeholder product artwork with the provided assets that match each description

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc4ffef2f4832a998c3fcffd13eff8