### PR TITLE
Add contact icon button and tighten hero spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,6 +193,31 @@
           >
         </span>
       </button>
+      <a class="icon-btn contact" href="mailto:hello@hobbykollector.com" aria-label="Contact me">
+        <span class="icon-wrapper">
+          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"
+            ><rect
+              x="3"
+              y="5"
+              width="18"
+              height="14"
+              rx="2.5"
+              ry="2.5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linejoin="round"
+            /><path
+              d="M5 8l7 5 7-5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            /></svg
+          >
+        </span>
+      </a>
     </div>
   </header>
 

--- a/styles.css
+++ b/styles.css
@@ -52,7 +52,7 @@ body::after {
 }
 
 main {
-  padding: 5rem min(6vw, 80px) 7rem;
+  padding: 3rem min(6vw, 80px) 7rem;
 }
 
 h1,
@@ -224,7 +224,7 @@ a:hover,
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: clamp(2rem, 5vw, 4rem);
   align-items: center;
-  margin-top: 3.5rem;
+  margin-top: 2rem;
   margin-bottom: 5rem;
 }
 
@@ -630,11 +630,11 @@ body.scroll-animations .reveal-on-scroll.is-visible {
 
 @media (max-width: 720px) {
   main {
-    padding: 4rem min(5vw, 32px) 6rem;
+    padding: 2.75rem min(5vw, 32px) 6rem;
   }
 
   .hero {
-    margin-top: 2rem;
+    margin-top: 1.5rem;
   }
 
   .hero-stats {


### PR DESCRIPTION
## Summary
- add a mailto-based "Contact me" icon to the header actions so it matches the other animated buttons
- reduce the spacing between the sticky banner and hero section for desktop and mobile breakpoints

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc541ac810832a8c2f7ba667d903eb