### PR TITLE
Animate logo reveal

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,12 +16,12 @@
   />
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
+<body id="top">
   <header class="site-header">
-    <div class="logo" aria-label="Hobby Kollector home">
-      <span class="logo-mark">HK</span>
+    <a class="logo" href="#top" aria-label="Hobby Kollector home">
+      <span class="logo-mark" aria-hidden="true">HK</span>
       <span class="logo-type">Hobby Kollector</span>
-    </div>
+    </a>
     <nav class="primary-nav" aria-label="Primary">
       <ul class="nav-list">
         <li>

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,7 @@
   --radius-md: 18px;
   --radius-pill: 999px;
   --content-max: 1200px;
+  --logo-ease: cubic-bezier(0.35, 0.9, 0.4, 1);
 }
 
 * {
@@ -97,17 +98,27 @@ a:hover,
 }
 
 .logo {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0;
   font-weight: 600;
   font-size: 1.05rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: #151728;
+  padding: 0.15rem 0.4rem 0.15rem 0;
+  border-radius: 1.2rem;
+  isolation: isolate;
+}
+
+.logo:focus-visible {
+  outline: 2px solid rgba(108, 75, 255, 0.45);
+  outline-offset: 4px;
 }
 
 .logo-mark {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -118,7 +129,92 @@ a:hover,
   color: #fff;
   font-size: 1.1rem;
   font-weight: 700;
-  box-shadow: 0 12px 24px rgba(108, 75, 255, 0.32);
+  box-shadow: 0 12px 24px rgba(108, 75, 255, 0.32), 0 0 12px rgba(108, 75, 255, 0.4);
+  overflow: hidden;
+  animation: logoMarkGlow 4.8s ease-in-out infinite;
+}
+
+.logo-mark::before {
+  content: "";
+  position: absolute;
+  top: -65%;
+  left: -65%;
+  width: 230%;
+  height: 230%;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.75) 45%, rgba(255, 255, 255, 0) 70%);
+  opacity: 0;
+  transform: translateX(-120%) rotate(24deg);
+  mix-blend-mode: screen;
+  animation: logoMarkShimmer 5s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.logo-type {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 0;
+  padding-left: 0;
+  opacity: 0;
+  transform: translateX(-0.75rem);
+  transition:
+    transform 0.55s var(--logo-ease),
+    opacity 0.3s ease,
+    max-width 0.55s var(--logo-ease),
+    padding-left 0.45s var(--logo-ease);
+  transition-delay: 3s, 3s, 3s, 3s;
+  color: #1f2133;
+  letter-spacing: 0.12em;
+}
+
+.logo:hover .logo-type,
+.logo:focus-visible .logo-type {
+  max-width: 16rem;
+  opacity: 1;
+  transform: translateX(0);
+  padding-left: 0.75rem;
+  transition-delay: 0s, 0s, 0s, 0s;
+}
+
+@keyframes logoMarkGlow {
+  0%,
+  100% {
+    box-shadow: 0 12px 24px rgba(108, 75, 255, 0.32), 0 0 10px rgba(108, 75, 255, 0.45), 0 0 18px rgba(60, 200, 171, 0.32);
+  }
+  50% {
+    box-shadow: 0 16px 30px rgba(108, 75, 255, 0.45), 0 0 18px rgba(108, 75, 255, 0.65), 0 0 26px rgba(60, 200, 171, 0.4);
+  }
+}
+
+@keyframes logoMarkShimmer {
+  0% {
+    transform: translateX(-120%) rotate(24deg);
+    opacity: 0;
+  }
+  35% {
+    opacity: 0.05;
+  }
+  50% {
+    opacity: 0.6;
+  }
+  65% {
+    opacity: 0.05;
+  }
+  100% {
+    transform: translateX(115%) rotate(24deg);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .logo-mark {
+    animation: none;
+  }
+
+  .logo-mark::before {
+    animation: none;
+    opacity: 0;
+  }
 }
 
 .primary-nav {


### PR DESCRIPTION
## Summary
- add a shimmering glow animation to the HK logo mark and expose it as a focusable home link anchor
- hide the "Hobby Kollector" wordmark inside the logo and reveal it with a sliding hover/focus animation that lingers for three seconds after exit

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cc5711835c832a8ff76cd2e7c99cc8