### PR TITLE
Improve mobile layout with drawer nav and sliders

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,15 +18,30 @@
 </head>
 <body id="top">
   <header class="site-header">
-    <a class="logo" href="#top" aria-label="Hobby Kollector home">
-      <span class="logo-mark" aria-hidden="true">HK</span>
-      <span class="logo-type">Hobby Kollector</span>
-    </a>
-    <nav class="primary-nav" aria-label="Primary">
-      <ul class="nav-list">
-        <li>
-          <a class="nav-link" href="#ceramics">
-            <span class="nav-icon" aria-hidden="true">
+    <div class="header-main">
+      <button
+        class="menu-toggle"
+        type="button"
+        aria-expanded="false"
+        aria-controls="primary-navigation"
+        aria-label="Open navigation menu"
+      >
+        <span class="sr-only">Menu</span>
+        <span class="menu-icon" aria-hidden="true">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+      </button>
+      <a class="logo" href="#top" aria-label="Hobby Kollector home">
+        <span class="logo-mark" aria-hidden="true">HK</span>
+        <span class="logo-type">Hobby Kollector</span>
+      </a>
+      <nav class="primary-nav" id="primary-navigation" aria-label="Primary">
+        <ul class="nav-list">
+          <li>
+            <a class="nav-link" href="#ceramics">
+              <span class="nav-icon" aria-hidden="true">
               <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"
                 ><path
                   d="M6 4h20l-2 12a8 8 0 01-7 6.9V28h4"
@@ -47,10 +62,10 @@
             </span>
             <span class="nav-text">Ceramics</span>
           </a>
-        </li>
-        <li>
-          <a class="nav-link" href="#stickers">
-            <span class="nav-icon" aria-hidden="true">
+          </li>
+          <li>
+            <a class="nav-link" href="#stickers">
+              <span class="nav-icon" aria-hidden="true">
               <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"
                 ><path
                   d="M10 5h12a3 3 0 013 3v12a7 7 0 01-7 7H9a2 2 0 01-2-2V10a5 5 0 015-5z"
@@ -71,10 +86,10 @@
             </span>
             <span class="nav-text">Stickers</span>
           </a>
-        </li>
-        <li>
-          <a class="nav-link" href="#woodwork">
-            <span class="nav-icon" aria-hidden="true">
+          </li>
+          <li>
+            <a class="nav-link" href="#woodwork">
+              <span class="nav-icon" aria-hidden="true">
               <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"
                 ><path
                   d="M6 17l5 11h10l5-11"
@@ -95,10 +110,10 @@
             </span>
             <span class="nav-text">Woodwork</span>
           </a>
-        </li>
-        <li>
-          <a class="nav-link" href="#painting">
-            <span class="nav-icon" aria-hidden="true">
+          </li>
+          <li>
+            <a class="nav-link" href="#painting">
+              <span class="nav-icon" aria-hidden="true">
               <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"
                 ><path
                   d="M4 27c2.2-5.8 7.6-9.6 13.6-9.1l6.4-6.4a3 3 0 10-4.2-4.2l-6.4 6.4C13 19.7 9 24.5 4 27z"
@@ -112,20 +127,20 @@
             </span>
             <span class="nav-text">Painting</span>
           </a>
-        </li>
-        <li>
-          <a class="nav-link" href="#digital">
-            <span class="nav-icon" aria-hidden="true">
+          </li>
+          <li>
+            <a class="nav-link" href="#digital">
+              <span class="nav-icon" aria-hidden="true">
               <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"
                 ><rect x="5" y="6" width="22" height="16" rx="3" ry="3" fill="none" stroke="currentColor" stroke-width="2" /><path d="M12 26h8" stroke="currentColor" stroke-width="2" stroke-linecap="round" /></svg
               >
             </span>
             <span class="nav-text">Digital Projects</span>
           </a>
-        </li>
-        <li>
-          <a class="nav-link" href="#gallery">
-            <span class="nav-icon" aria-hidden="true">
+          </li>
+          <li>
+            <a class="nav-link" href="#gallery">
+              <span class="nav-icon" aria-hidden="true">
               <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"
                 ><rect x="4" y="7" width="24" height="18" rx="3" ry="3" fill="none" stroke="currentColor" stroke-width="2" /><path
                   d="M10 17l4-4 4 4 4-3 4 4"
@@ -139,13 +154,13 @@
             </span>
             <span class="nav-text">Gallery</span>
           </a>
-        </li>
-      </ul>
-    </nav>
-    <div class="header-actions">
-      <button class="icon-btn search" type="button" aria-label="Search the site">
-        <span class="icon-wrapper">
-          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+          </li>
+        </ul>
+      </nav>
+      <div class="header-actions">
+        <button class="icon-btn search" type="button" aria-label="Search the site">
+          <span class="icon-wrapper">
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
             ><circle cx="11" cy="11" r="6" fill="none" stroke="currentColor" stroke-width="2" /><line
               x1="16"
               y1="16"
@@ -218,7 +233,9 @@
           >
         </span>
       </a>
+      </div>
     </div>
+    <div class="nav-overlay" hidden aria-hidden="true"></div>
   </header>
 
   <main>

--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,7 @@
   --radius-pill: 999px;
   --content-max: 1200px;
   --logo-ease: cubic-bezier(0.35, 0.9, 0.4, 1);
+  --header-offset: 0px;
 }
 
 * {
@@ -53,7 +54,7 @@ body::after {
 }
 
 main {
-  padding: 3rem min(6vw, 80px) 7rem;
+  padding: calc(3rem + var(--header-offset)) min(6vw, 80px) 7rem;
 }
 
 h1,
@@ -85,11 +86,7 @@ a:hover,
 .site-header {
   position: sticky;
   top: 0;
-  z-index: 10;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1.5rem;
+  z-index: 30;
   padding: 1.15rem min(6vw, 80px);
   background: rgba(248, 246, 255, 0.82);
   backdrop-filter: blur(18px) saturate(140%);
@@ -97,11 +94,105 @@ a:hover,
   box-shadow: 0 18px 35px rgba(88, 90, 104, 0.12);
 }
 
+.header-main {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.menu-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 1.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  background: var(--surface-strong);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+  transition: box-shadow 0.45s cubic-bezier(0.33, 1, 0.68, 1), transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
+  position: relative;
+  z-index: 60;
+}
+
+.menu-toggle:hover,
+.menu-toggle:focus-visible {
+  box-shadow: var(--shadow-soft);
+  transform: translateY(-1px);
+}
+
+.menu-toggle:focus-visible {
+  outline: 2px solid rgba(108, 75, 255, 0.4);
+  outline-offset: 2px;
+}
+
+.menu-icon {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.menu-icon span {
+  display: block;
+  width: 1.5rem;
+  height: 0.16rem;
+  background: #1f2133;
+  border-radius: 999px;
+  transition: transform 0.35s cubic-bezier(0.33, 1, 0.68, 1), opacity 0.3s ease;
+}
+
+body.nav-open .menu-icon span:nth-child(1) {
+  transform: translateY(0.46rem) rotate(45deg);
+}
+
+body.nav-open .menu-icon span:nth-child(2) {
+  opacity: 0;
+}
+
+body.nav-open .menu-icon span:nth-child(3) {
+  transform: translateY(-0.46rem) rotate(-45deg);
+}
+
+.nav-overlay {
+  display: none;
+}
+
+.nav-overlay[hidden] {
+  display: none !important;
+}
+
+.header-main > .logo {
+  grid-column: 1;
+}
+
+.header-main > .primary-nav {
+  grid-column: 2;
+  justify-self: center;
+}
+
+.header-main > .header-actions {
+  grid-column: 3;
+  justify-self: end;
+}
+
 .logo {
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 0;
+  gap: 0.75rem;
   font-weight: 600;
   font-size: 1.05rem;
   text-transform: uppercase;
@@ -131,7 +222,6 @@ a:hover,
   font-weight: 700;
   box-shadow: 0 12px 24px rgba(108, 75, 255, 0.32), 0 0 12px rgba(108, 75, 255, 0.4);
   overflow: hidden;
-  animation: logoMarkGlow 4.8s ease-in-out infinite;
 }
 
 .logo-mark::before {
@@ -145,60 +235,45 @@ a:hover,
   opacity: 0;
   transform: translateX(-120%) rotate(24deg);
   mix-blend-mode: screen;
-  animation: logoMarkShimmer 5s ease-in-out infinite;
   pointer-events: none;
+}
+
+.logo-mark.is-shimmering {
+  animation: logoMarkGlowOnce 1.6s ease forwards;
+}
+
+.logo-mark.is-shimmering::before {
+  animation: logoMarkSweep 1.6s ease forwards;
 }
 
 .logo-type {
   display: inline-block;
-  overflow: hidden;
-  white-space: nowrap;
-  max-width: 0;
-  padding-left: 0;
-  opacity: 0;
-  transform: translateX(-0.75rem);
-  transition:
-    transform 0.55s var(--logo-ease),
-    opacity 0.3s ease,
-    max-width 0.55s var(--logo-ease),
-    padding-left 0.45s var(--logo-ease);
-  transition-delay: 3s, 3s, 3s, 3s;
   color: #1f2133;
   letter-spacing: 0.12em;
 }
 
-.logo:hover .logo-type,
-.logo:focus-visible .logo-type {
-  max-width: 16rem;
-  opacity: 1;
-  transform: translateX(0);
-  padding-left: 0.75rem;
-  transition-delay: 0s, 0s, 0s, 0s;
-}
-
-@keyframes logoMarkGlow {
-  0%,
+@keyframes logoMarkGlowOnce {
+  0% {
+    box-shadow: 0 12px 24px rgba(108, 75, 255, 0.32), 0 0 10px rgba(108, 75, 255, 0.38), 0 0 16px rgba(60, 200, 171, 0.26);
+  }
+  45% {
+    box-shadow: 0 20px 36px rgba(108, 75, 255, 0.5), 0 0 22px rgba(108, 75, 255, 0.7), 0 0 30px rgba(60, 200, 171, 0.36);
+  }
   100% {
-    box-shadow: 0 12px 24px rgba(108, 75, 255, 0.32), 0 0 10px rgba(108, 75, 255, 0.45), 0 0 18px rgba(60, 200, 171, 0.32);
-  }
-  50% {
-    box-shadow: 0 16px 30px rgba(108, 75, 255, 0.45), 0 0 18px rgba(108, 75, 255, 0.65), 0 0 26px rgba(60, 200, 171, 0.4);
+    box-shadow: 0 12px 24px rgba(108, 75, 255, 0.32), 0 0 10px rgba(108, 75, 255, 0.4), 0 0 16px rgba(60, 200, 171, 0.26);
   }
 }
 
-@keyframes logoMarkShimmer {
+@keyframes logoMarkSweep {
   0% {
     transform: translateX(-120%) rotate(24deg);
     opacity: 0;
   }
-  35% {
-    opacity: 0.05;
+  40% {
+    opacity: 0.65;
   }
-  50% {
-    opacity: 0.6;
-  }
-  65% {
-    opacity: 0.05;
+  60% {
+    opacity: 0.3;
   }
   100% {
     transform: translateX(115%) rotate(24deg);
@@ -207,18 +282,22 @@ a:hover,
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .logo-mark {
-    animation: none;
+  .logo-mark,
+  .logo-mark.is-shimmering {
+    animation: none !important;
   }
 
-  .logo-mark::before {
-    animation: none;
+  .logo-mark::before,
+  .logo-mark.is-shimmering::before {
+    animation: none !important;
     opacity: 0;
   }
 }
 
 .primary-nav {
-  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .nav-list {
@@ -699,34 +778,130 @@ body.scroll-animations .reveal-on-scroll.is-visible {
 /* Responsive adjustments */
 
 @media (max-width: 960px) {
+  .header-main {
+    gap: 1.2rem;
+  }
+}
+
+@media (max-width: 780px) {
+  :root {
+    --header-offset: clamp(4.8rem, 14vw, 5.6rem);
+  }
+
   .site-header {
-    flex-wrap: wrap;
+    position: fixed;
+    left: 0;
+    right: 0;
+    padding: 1rem clamp(1.5rem, 6vw, 2.4rem);
+  }
+
+  .header-main {
+    grid-template-columns: auto 1fr auto;
     gap: 1rem;
   }
 
-  .primary-nav {
-    order: 3;
-    width: 100%;
+  .menu-toggle {
+    display: inline-flex;
   }
 
-  .nav-list {
-    justify-content: flex-start;
-    overflow-x: auto;
-    padding-bottom: 0.5rem;
+  .header-main > .logo {
+    grid-column: 3;
+    justify-self: end;
+  }
+
+  .header-main > .header-actions {
+    grid-column: 2;
+    justify-self: center;
+  }
+
+  .header-main > .primary-nav {
+    grid-column: 1 / -1;
+    justify-self: stretch;
   }
 
   .header-actions {
-    order: 2;
+    gap: 0.75rem;
+    justify-content: center;
   }
 
-  .logo {
-    order: 1;
+  .icon-btn,
+  .icon-wrapper {
+    transition: none;
+  }
+
+  .icon-btn:hover,
+  .icon-btn:focus-visible {
+    transform: none;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  }
+
+  .primary-nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    width: min(320px, 78vw);
+    padding: clamp(4.25rem, 14vw, 6rem) 1.75rem 2.5rem;
+    background: rgba(248, 246, 255, 0.95);
+    backdrop-filter: blur(18px) saturate(130%);
+    border-right: 1px solid rgba(255, 255, 255, 0.7);
+    box-shadow: 0 22px 45px rgba(21, 23, 40, 0.22);
+    transform: translateX(-100%);
+    transition: transform 0.4s cubic-bezier(0.33, 1, 0.68, 1);
+    display: flex;
+    justify-content: flex-start;
+    overflow-y: auto;
+    pointer-events: none;
+    z-index: 40;
+  }
+
+  body.nav-open .primary-nav {
+    transform: translateX(0);
+    pointer-events: auto;
+  }
+
+  .nav-list {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.85rem;
+    width: 100%;
+  }
+
+  .nav-link {
+    width: 100%;
+    justify-content: flex-start;
+    font-size: 1.05rem;
+    padding: 0.85rem 1rem;
+  }
+
+  .nav-overlay {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(22, 24, 43, 0.4);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+    z-index: 35;
+  }
+
+  body.nav-open .nav-overlay {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  body.nav-open {
+    overflow: hidden;
+  }
+
+  .logo-type {
+    display: none;
   }
 }
 
 @media (max-width: 720px) {
   main {
-    padding: 2.75rem min(5vw, 32px) 6rem;
+    padding: calc(2.75rem + var(--header-offset)) min(5vw, 32px) 6rem;
   }
 
   .hero {
@@ -735,6 +910,54 @@ body.scroll-animations .reveal-on-scroll.is-visible {
 
   .hero-stats {
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .header-actions {
+    justify-content: center;
+  }
+
+  .product-grid {
+    position: relative;
+    grid-template-columns: minmax(0, 1fr);
+    min-height: var(--mobile-card-height, auto);
+    overflow: hidden;
+  }
+
+  .product-grid .product-card {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translateY(18px);
+    transition: opacity 0.6s ease, transform 0.6s ease, box-shadow 0.4s cubic-bezier(0.33, 1, 0.68, 1);
+  }
+
+  .product-grid .product-card.is-active {
+    position: relative;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .product-grid .product-card:first-child {
+    position: relative;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .product-card {
+    padding: 1.2rem;
+    gap: 1rem;
+  }
+
+  .product-meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.45rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a sticky mobile drawer navigation with a hamburger toggle and centered header icons
- implement a scroll-triggered shimmer for the HK logo and mobile-friendly single-card category carousel
- update styles and scripts to support the new mobile presentation while preserving desktop layout

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc5bbd7c8c832aacaff878747929ce