### PR TITLE
Remove logo shimmer on scroll and align mobile header icons

### DIFF
--- a/script.js
+++ b/script.js
@@ -84,45 +84,6 @@ document.addEventListener('DOMContentLoaded', () => {
     navOverlay.setAttribute('hidden', '');
   }
 
-  const logoMark = document.querySelector('.logo-mark');
-  let shimmerCooldown = false;
-  let shimmerScheduled = false;
-
-  if (logoMark) {
-    const triggerLogoShimmer = () => {
-      if (shimmerCooldown || prefersReducedMotion) {
-        return;
-      }
-      shimmerCooldown = true;
-      logoMark.classList.add('is-shimmering');
-      logoMark.addEventListener(
-        'animationend',
-        () => {
-          logoMark.classList.remove('is-shimmering');
-        },
-        { once: true }
-      );
-      window.setTimeout(() => {
-        shimmerCooldown = false;
-      }, 1700);
-    };
-
-    const handleScrollShimmer = () => {
-      if (prefersReducedMotion || shimmerScheduled) {
-        return;
-      }
-      shimmerScheduled = true;
-      requestAnimationFrame(() => {
-        if (window.scrollY > 6) {
-          triggerLogoShimmer();
-        }
-        shimmerScheduled = false;
-      });
-    };
-
-    window.addEventListener('scroll', handleScrollShimmer, { passive: true });
-  }
-
   const observerOptions = {
     threshold: 0.2,
     rootMargin: '0px 0px -10% 0px'
@@ -262,9 +223,6 @@ document.addEventListener('DOMContentLoaded', () => {
   reduceMotionQuery.addEventListener('change', (event) => {
     prefersReducedMotion = event.matches;
     if (prefersReducedMotion) {
-      shimmerCooldown = false;
-      shimmerScheduled = false;
-      logoMark?.classList.remove('is-shimmering');
       applyMobileSlider(false);
     } else {
       applyMobileSlider(mobileSliderQuery.matches);

--- a/styles.css
+++ b/styles.css
@@ -811,7 +811,9 @@ body.scroll-animations .reveal-on-scroll.is-visible {
 
   .header-main > .header-actions {
     grid-column: 2;
+    grid-row: 1;
     justify-self: center;
+    align-self: start;
   }
 
   .header-main > .primary-nav {
@@ -822,6 +824,7 @@ body.scroll-animations .reveal-on-scroll.is-visible {
   .header-actions {
     gap: 0.75rem;
     justify-content: center;
+    align-items: flex-start;
   }
 
   .icon-btn,


### PR DESCRIPTION
## Summary
- remove the scroll-based logic that added the logo shimmer effect
- simplify the reduced-motion listener now that shimmering is disabled
- ensure the mobile header action icons occupy the first grid row and align with the top edge

## Testing
- python3 -m http.server 8000 (manual visual verification)


------
https://chatgpt.com/codex/tasks/task_e_68cc6784efec832ab9f295246b12aa3d