### PR TITLE
Add desktop scroll-to-top control

### DIFF
--- a/index.html
+++ b/index.html
@@ -753,6 +753,19 @@
     <p class="footer-note">© <span id="year"></span> Hobby Kollector. All rights reserved.</p>
   </footer>
 
+  <button class="scroll-top" type="button" aria-label="Back to top">
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        d="M12 5l-6 6h3.6v8h4.8v-8H18l-6-6z"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  </button>
+
   <script src="script.js" defer></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -13,6 +13,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const menuToggle = document.querySelector('.menu-toggle');
   const primaryNav = document.querySelector('.primary-nav');
   const navOverlay = document.querySelector('.nav-overlay');
+  const scrollTopButton = document.querySelector('.scroll-top');
+  const scrollTopDesktopQuery = window.matchMedia('(min-width: 900px)');
   let navFocusTimeout = null;
 
   const closeNav = (returnFocus = false) => {
@@ -229,8 +231,41 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  const setScrollTopVisibility = (isVisible) => {
+    if (!scrollTopButton) return;
+    scrollTopButton.classList.toggle('is-visible', isVisible);
+    if (isVisible) {
+      scrollTopButton.removeAttribute('aria-hidden');
+      scrollTopButton.removeAttribute('tabindex');
+    } else {
+      scrollTopButton.setAttribute('aria-hidden', 'true');
+      scrollTopButton.setAttribute('tabindex', '-1');
+    }
+  };
+
+  const updateScrollTopVisibility = () => {
+    if (!scrollTopButton) return;
+    const shouldShow = scrollTopDesktopQuery.matches && window.scrollY > 160;
+    setScrollTopVisibility(shouldShow);
+  };
+
+  if (scrollTopButton) {
+    scrollTopButton.addEventListener('click', () => {
+      if (prefersReducedMotion) {
+        window.scrollTo({ top: 0 });
+      } else {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }
+    });
+
+    window.addEventListener('scroll', updateScrollTopVisibility, { passive: true });
+    scrollTopDesktopQuery.addEventListener('change', updateScrollTopVisibility);
+    updateScrollTopVisibility();
+  }
+
   window.addEventListener('resize', () => {
     sliderStates.forEach((state) => state.updateHeight());
+    updateScrollTopVisibility();
   });
 
   const supportsHover = window.matchMedia('(hover: hover) and (pointer: fine)').matches;

--- a/styles.css
+++ b/styles.css
@@ -775,6 +775,57 @@ body.scroll-animations .reveal-on-scroll.is-visible {
   transition-duration: 0.45s;
 }
 
+.scroll-top {
+  position: fixed;
+  bottom: clamp(2rem, 4vw, 3rem);
+  right: clamp(2rem, 4vw, 3rem);
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: var(--radius-pill);
+  background: rgba(24, 26, 43, 0.6);
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  backdrop-filter: blur(12px) saturate(140%);
+  box-shadow: 0 26px 48px rgba(24, 26, 43, 0.25);
+  transition: opacity 0.3s ease, transform 0.3s ease, background 0.3s ease, box-shadow 0.3s ease;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(16px);
+  z-index: 90;
+}
+
+.scroll-top svg {
+  width: 1.35rem;
+  height: 1.35rem;
+}
+
+.scroll-top.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.scroll-top:hover,
+.scroll-top:focus-visible {
+  background: rgba(108, 75, 255, 0.82);
+  box-shadow: 0 30px 56px rgba(68, 70, 84, 0.3);
+}
+
+.scroll-top:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 4px;
+}
+
+@media (max-width: 899px) {
+  .scroll-top {
+    display: none;
+  }
+}
+
 /* Responsive adjustments */
 
 @media (max-width: 960px) {


### PR DESCRIPTION
## Summary
- add a scroll-to-top control near the footer for desktop layouts
- style the control with a rounded, translucent appearance and hide it on small viewports
- toggle the control with scroll position while honoring reduced-motion preferences

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc6c6dbab4832aa51216e257ac5893