### PR TITLE
Improve navigation chip contrast

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -9,6 +9,12 @@
   --accent-warm: #ff8a65;
   --accent-cool: #3cc8ab;
   --accent-soft: rgba(108, 75, 255, 0.14);
+  --nav-chip-bg: linear-gradient(135deg, rgba(108, 75, 255, 0.16), rgba(60, 200, 171, 0.1));
+  --nav-chip-border: rgba(108, 75, 255, 0.28);
+  --nav-chip-hover-border: rgba(108, 75, 255, 0.45);
+  --nav-chip-text: #1c1f33;
+  --nav-chip-hover-bg: linear-gradient(135deg, rgba(108, 75, 255, 0.32), rgba(60, 200, 171, 0.22));
+  --nav-chip-hover-text: #101225;
   --shadow-soft: 0 22px 45px rgba(41, 45, 62, 0.16);
   --shadow-strong: 0 30px 60px rgba(68, 70, 84, 0.22);
   --radius-lg: 26px;
@@ -317,25 +323,27 @@ body.nav-open .menu-icon span:nth-child(3) {
   gap: 0.55rem;
   padding: 0.6rem 0.95rem;
   border-radius: var(--radius-pill);
-  color: #373b50;
+  color: var(--nav-chip-text);
   font-weight: 500;
-  background: rgba(255, 255, 255, 0.4);
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
-  transition: color 0.3s ease, background 0.35s ease, box-shadow 0.35s ease, transform 0.35s ease;
+  background: var(--nav-chip-bg);
+  border: 1px solid var(--nav-chip-border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3), 0 10px 22px rgba(84, 88, 136, 0.18);
+  transition: color 0.3s ease, background 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease, transform 0.35s ease;
 }
 
 .nav-link .nav-icon svg {
   width: 1.25rem;
   height: 1.25rem;
+  color: rgba(28, 30, 54, 0.7);
   transition: color 0.3s ease;
 }
 
 .nav-link:hover,
 .nav-link:focus-visible {
-  background: linear-gradient(135deg, rgba(108, 75, 255, 0.18), rgba(60, 200, 171, 0.16));
-  color: #17192c;
-  box-shadow: 0 12px 26px rgba(76, 96, 163, 0.25);
+  background: var(--nav-chip-hover-bg);
+  border-color: var(--nav-chip-hover-border);
+  color: var(--nav-chip-hover-text);
+  box-shadow: 0 16px 32px rgba(75, 88, 166, 0.32);
   transform: translateY(-2px);
 }
 


### PR DESCRIPTION
## Summary
- add theme variables for navigation chip colors derived from the existing accent palette
- restyle navigation links with tinted backgrounds, stronger borders, and deeper shadows for better contrast
- update hover styling and icon colors to preserve contrast on interaction

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cc7135026c832ab2ebb3d263fe095f