### PR TITLE
Center search icon in search panel

### DIFF
--- a/src/css/components.css
+++ b/src/css/components.css
@@ -252,6 +252,7 @@ body.nav-open .menu-icon span:nth-child(3) {
 
 .search-panel .icon-wrapper {
   display: grid;
+  place-items: center;
 }
 
 .search-panel .icon-arrow {


### PR DESCRIPTION
## Summary
- center the search icon within the collapsed search trigger button by aligning its wrapper grid

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc8bf1b658832a85f0968c94bf358d